### PR TITLE
feat: 페이지네이션 추가 및 메인 헤더 화면 줄어들때 반응형으로 처리

### DIFF
--- a/src/components/Header/MainHeader.tsx
+++ b/src/components/Header/MainHeader.tsx
@@ -8,7 +8,7 @@ import LoginModal from '../Login/LoginModal';
 const MainHeader = () => {
   const { openLoginModal } = useLoginMoalStore();
   return (
-    <header className="fixed top-0 left-7.1 w-[1440px] bg-black z-50 flex justify-between py-5 px-50px">
+    <header className="fixed top-0 left-1/2 -translate-x-1/2 w-full max-w-[1440px] bg-black z-50 flex justify-between py-5 px-12">
       <img src={logo} alt="logo" />
       <div className="flex gap-12 w-[222px]">
         <img src={search} alt="search_logo" />

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,0 +1,34 @@
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+} from '../ui/pagination';
+
+const MainPagination = () => {
+  return (
+    <Pagination>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationLink>01</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink>02</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink>03</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationEllipsis />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationNext />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  );
+};
+
+export default MainPagination;

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,17 +5,21 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 dark:ring-offset-neutral-950 dark:focus-visible:ring-neutral-300',
   {
     variants: {
       variant: {
-        default: 'bg-neutral-900 text-neutral-50 hover:bg-neutral-900/90',
-        destructive: 'bg-red-500 text-neutral-50 hover:bg-red-500/90',
-        outline: 'border border-neutral-200 bg-white hover:bg-neutral-100 hover:text-neutral-900',
-        secondary: 'bg-neutral-100 text-neutral-900 hover:bg-neutral-100/80',
-        ghost: 'hover:bg-neutral-100 hover:text-neutral-900',
-        link: 'text-neutral-900 underline-offset-4 hover:underline',
-        pagenation: 'border border-neutral-200 bg-neutral-100 hover:text-neutral-900',
+        default:
+          'bg-neutral-900 text-neutral-50 hover:bg-neutral-900/90 dark:bg-neutral-50 dark:text-neutral-900 dark:hover:bg-neutral-50/90',
+        destructive:
+          'bg-red-500 text-neutral-50 hover:bg-red-500/90 dark:bg-red-900 dark:text-neutral-50 dark:hover:bg-red-900/90',
+        outline:
+          'border border-neutral-200 bg-white hover:bg-neutral-100 hover:text-neutral-900 dark:border-neutral-800 dark:bg-neutral-950 dark:hover:bg-neutral-800 dark:hover:text-neutral-50',
+        secondary:
+          'bg-neutral-100 text-neutral-900 hover:bg-neutral-100/80 dark:bg-neutral-800 dark:text-neutral-50 dark:hover:bg-neutral-800/80',
+        ghost:
+          'hover:bg-neutral-100 hover:text-neutral-900 dark:hover:bg-neutral-800 dark:hover:text-neutral-50',
+        link: 'text-neutral-900 underline-offset-4 hover:underline dark:text-neutral-50',
       },
       size: {
         default: 'h-10 px-4 py-2',

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -36,7 +36,7 @@ const PaginationLink = ({ className, isActive, size = 'icon', ...props }: Pagina
     aria-current={isActive ? 'page' : undefined}
     className={cn(
       buttonVariants({
-        variant: isActive ? 'pagenation' : 'ghost',
+        variant: isActive ? 'outline' : 'ghost',
         size,
       }),
       className
@@ -53,10 +53,11 @@ const PaginationPrevious = ({
   <PaginationLink
     aria-label="Go to previous page"
     size="default"
-    className={cn('p-2.5 border', className)}
+    className={cn('gap-1 pl-2.5', className)}
     {...props}
   >
-    <ChevronLeft className="w-4 h-4" />
+    <ChevronLeft className="h-4 w-4" />
+    <span>Previous</span>
   </PaginationLink>
 );
 PaginationPrevious.displayName = 'PaginationPrevious';
@@ -65,10 +66,11 @@ const PaginationNext = ({ className, ...props }: React.ComponentProps<typeof Pag
   <PaginationLink
     aria-label="Go to next page"
     size="default"
-    className={cn('p-2.5 border', className)}
+    className={cn('gap-1 pr-2.5', className)}
     {...props}
   >
-    <ChevronRight className="w-4 h-4" />
+    <span>다음</span>
+    <ChevronRight className="h-4 w-4" />
   </PaginationLink>
 );
 PaginationNext.displayName = 'PaginationNext';
@@ -79,7 +81,7 @@ const PaginationEllipsis = ({ className, ...props }: React.ComponentProps<'span'
     className={cn('flex h-9 w-9 items-center justify-center', className)}
     {...props}
   >
-    <MoreHorizontal className="w-4 h-4" />
+    <MoreHorizontal className="h-4 w-4" />
     <span className="sr-only">More pages</span>
   </span>
 );

--- a/src/feature/homepage/SortByLog.tsx
+++ b/src/feature/homepage/SortByLog.tsx
@@ -1,15 +1,14 @@
-import React from "react";
+import MainPagination from '@/components/Pagination/Pagination';
+import React from 'react';
 
 const SortByLog = () => {
   return (
     <div className="w-full h-[1524px] ">
       <div className="flex w-[156px] flex-col gap-4 mb-12">
-        <div className="font-untitled text-32 h-[23px] text-[#ABAFB5]">
-          Sort by
-        </div>
+        <div className="font-untitled text-32 h-[23px] text-[#ABAFB5]">Sort by</div>
         <div className="font-untitled text-32 h-[23px] text-[#242528]">Log</div>
       </div>
-      <div className="w-full flex">
+      <div className="w-full flex mb-12">
         <div className="w-1/2  h-[1328px] flex flex-wrap">
           <div className="w-[314px] mr-5">
             <div className="w-full h-[218px] bg-red-100 mb-2"></div>
@@ -132,6 +131,7 @@ const SortByLog = () => {
           </div>
         </div>
       </div>
+      <MainPagination />
     </div>
   );
 };

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,5 +1,4 @@
 import MainFooter from '../../components/Footer/MainFooter';
-import MainHeader from '../../components/Header/MainHeader';
 import HomePageIntroContent from '../../feature/homepage/HomePageIntroContent';
 import SortByLog from '../../feature/homepage/SortByLog';
 import SortByPopularity from '../../feature/homepage/SortByPopularity';


### PR DESCRIPTION
## 작업 내용

- 메인 헤더 화면 줄어듬에 따라 반응형으로 줄어들게 적용
- 작동하지 않는 페이지네이션 추가 (shad/cn)

## 문제 발견
- 메인 헤더의 로그인 버튼을 눌렀을 때 발생하는 모달창에서 발생
- 처음 누를때 카카오 로그인 버튼의 border가 보이는 현상 -> 두번째 클릭부터는 안보이는데 첫 클릭에 보이는 점이 문제 (스크린샷 첨부) 
- 및 이후 띄어쓰기
<img width="532" alt="스크린샷 2025-02-03 오후 4 57 44" src="https://github.com/user-attachments/assets/2697843f-848d-4747-a403-24825cb4d5ac" />

@rlaugs15 이 부분 수정해주시면 될 것 같습니다.