### PR TITLE
feat: 검색 기능 개선 및 검색 결과 페이지 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,12 @@
 import { Outlet } from 'react-router-dom';
 import MainHeader from './components/Header/MainHeader';
+import SearchBar from './components/SearchBar/SearchBar';
 
 const App = () => {
   return (
     <div className="flex flex-col items-center web:w-[1440px] web:mx-auto mobile:max-w-[768px]">
       <MainHeader />
+      <SearchBar />
       <Outlet />
     </div>
   );

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter } from 'react-router-dom';
 import App from './App';
 import HomePage from './pages/home';
+import Search from './pages/search';
 
 const router = createBrowserRouter([
   {
@@ -10,6 +11,10 @@ const router = createBrowserRouter([
       {
         index: true,
         element: <HomePage />,
+      },
+      {
+        path: 'search',
+        element: <Search />,
       },
     ],
   },

--- a/src/components/Header/MainHeader.tsx
+++ b/src/components/Header/MainHeader.tsx
@@ -4,14 +4,17 @@ import global from '../../assets/homepage/global.png';
 import signup from '../../assets/homepage/signup.png';
 import { useLoginMoalStore } from '@/store/loginStore';
 import LoginModal from '../Login/LoginModal';
+import { useSearchStore } from '@/store/searchStore';
 
 const MainHeader = () => {
   const { openLoginModal } = useLoginMoalStore();
+  const { toggleSearchBar } = useSearchStore();
+
   return (
     <header className="fixed top-0 left-7.1 w-[1440px] bg-black z-50 flex justify-between py-5 px-50px">
       <img src={logo} alt="logo" />
       <div className="flex gap-12 w-[222px]">
-        <img src={search} alt="search_logo" />
+        <img onClick={toggleSearchBar} src={search} alt="search_logo" />
         <img src={global} alt="global_logo" />
         <img
           onClick={openLoginModal}

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -5,9 +5,11 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { Input } from '@/components/ui/input';
 import { useNavigate } from 'react-router-dom';
 import SearchIcon from '../Icons/SearchIcon';
+import { useSearchStore } from '@/store/searchStore';
 
 function SearchBar() {
   const nav = useNavigate();
+  const { isOpen } = useSearchStore();
 
   const form = useForm<SearchForm>({
     resolver: zodResolver(searchSchema),
@@ -16,43 +18,53 @@ function SearchBar() {
     },
   });
 
+  const { toggleSearchBar } = useSearchStore();
+
   const onSearchSubmit = ({ title }: SearchForm) => {
     console.log(title);
     form.reset();
     nav('/search', {
       state: { title },
     });
+    toggleSearchBar();
   };
   return (
-    <nav className="web:px-[50px] py-[30px] mobile:px-4 w-full flex justify-center items-center bg-black">
-      <Form {...form}>
-        <form
-          onSubmit={form.handleSubmit(onSearchSubmit)}
-          className="flex w-[655px] p-0 h-auto items-center bg-formBlack"
-        >
-          <FormField
-            control={form.control}
-            name="title"
-            render={({ field }) => (
-              <FormItem className="flex-1">
-                <FormControl>
-                  <Input
-                    placeholder="제가 찾는 건..."
-                    {...field}
-                    style={{ color: 'white' }}
-                    className="bg-inherit pl-[25px] caret-white text-white placeholder:text-[#575A63] text-17"
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <button className="px-[25px] py-[18px]">
-            <SearchIcon />
-          </button>
-        </form>
-      </Form>
-    </nav>
+    <>
+      {isOpen ? (
+        <>
+          <nav className="web:px-[50px] z-20 py-[30px] fixed top-[60px] mobile:px-4 web:w-[1440px] mobile:w-full flex justify-center items-center bg-black">
+            <Form {...form}>
+              <form
+                onSubmit={form.handleSubmit(onSearchSubmit)}
+                className="flex w-[655px] p-0 h-auto items-center bg-formBlack"
+              >
+                <FormField
+                  control={form.control}
+                  name="title"
+                  render={({ field }) => (
+                    <FormItem className="flex-1">
+                      <FormControl>
+                        <Input
+                          placeholder="제가 찾는 건..."
+                          {...field}
+                          style={{ color: 'white' }}
+                          className="bg-inherit pl-[25px] caret-white text-white placeholder:text-[#575A63] text-17"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <button className="px-[25px] py-[18px]">
+                  <SearchIcon />
+                </button>
+              </form>
+            </Form>
+          </nav>
+          <main className="fixed z-10 w-full h-screen web:w-[1440px] mobile:max-w-[768px] bg-black/80" />
+        </>
+      ) : null}
+    </>
   );
 }
 

--- a/src/feature/homepage/CitySearchForm.tsx
+++ b/src/feature/homepage/CitySearchForm.tsx
@@ -1,0 +1,33 @@
+function CitySearchForm() {
+  return (
+    <section className="w-full flex gap-[10px]">
+      <form className="flex gap-[10px] flex-1">
+        <div className="flex flex-col flex-1 gap-2 px-5 py-3 bg-white">
+          <label htmlFor="sido" className="text-[#81858F]">
+            어디로 놀러갈까요?
+          </label>
+          <input
+            id="sido"
+            type="text"
+            placeholder="전체"
+            className="placeholder:text-[20px] placeholder:font-bold placeholder:text-black"
+          />
+        </div>
+        <div className="flex flex-col flex-1 gap-2 px-5 py-3 bg-white">
+          <label htmlFor="gu" className="text-[#81858F]">
+            더 상세히 검색!
+          </label>
+          <input
+            id="gu"
+            type="text"
+            placeholder="전체"
+            className="placeholder:text-[20px] placeholder:font-bold placeholder:text-black"
+          />
+        </div>
+        <button className="p-5 text-16 bg-[#242528] text-white">검색</button>
+      </form>
+    </section>
+  );
+}
+
+export default CitySearchForm;

--- a/src/feature/homepage/HomePageIntroContent.tsx
+++ b/src/feature/homepage/HomePageIntroContent.tsx
@@ -1,46 +1,49 @@
-import ui from "../../assets/homepage/ui-spoteditor.png";
+import { useSearchStore } from '@/store/searchStore';
+import ui from '../../assets/homepage/ui-spoteditor.png';
 
 const HomePageIntroContent = () => {
   const category: string[] = [
-    "로.맨.틱 데이트 코스!",
-    "가성비 굿 하루",
-    "액티비티한 하루!",
-    "감성충전 미술관 데이트",
-    "홀로 독서하는 하루",
-    "찐하게 소비한 하루",
-    "친구랑 다양하고 알차게 보낸 하루",
+    '로.맨.틱 데이트 코스!',
+    '가성비 굿 하루',
+    '액티비티한 하루!',
+    '감성충전 미술관 데이트',
+    '홀로 독서하는 하루',
+    '찐하게 소비한 하루',
+    '친구랑 다양하고 알차게 보낸 하루',
   ];
-
+  const { isOpen } = useSearchStore();
   return (
-    <div className="w-full flex pt-24 py-10 h-[387px] gap-7 bg-black px-50px">
-      <div className="w-[655px] flex flex-col gap-9">
-        <div className="font-pretendard text-32 text-white font-500">
-          반가워요!
-          <br />
-          Spoteditor는 <span className="font-semibold">
-            "어디 가서 놀지?"
-          </span>{" "}
-          하고 고민하는
-          <br />
-          여러분을 위해 만들어졌어요.
+    <>
+      {!isOpen ? (
+        <div className="w-full flex pt-24 py-10 h-[387px] gap-7 bg-black px-50px">
+          <div className="w-[655px] flex flex-col gap-9 bg-red-300">
+            <div className="text-white font-pretendard text-32 font-500">
+              반가워요!
+              <br />
+              Spoteditor는 <span className="font-semibold">"어디 가서 놀지?"</span> 하고 고민하는
+              <br />
+              여러분을 위해 만들어졌어요.
+            </div>
+            <section className="w-full bg-blue-300"></section>
+          </div>
+          <div className="w-[655px] flex flex-col gap-5">
+            <img src={ui} alt="ui_spoteditior_description" />
+            <div className="flex flex-wrap gap-1.5">
+              {category.map((i) => {
+                return (
+                  <div
+                    key={i}
+                    className="flex h-8 justify-center items-center text-center px-3.5 py-3 rounded-full border border-[#424448] font-pretendard text-14 text-white w-auto"
+                  >
+                    {i}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
         </div>
-      </div>
-      <div className="w-[655px] flex flex-col gap-5">
-        <img src={ui} alt="ui_spoteditior_description" />
-        <div className="flex flex-wrap gap-1.5">
-          {category.map((i) => {
-            return (
-              <div
-                key={i}
-                className="flex h-8 justify-center items-center text-center px-3.5 py-3 rounded-full border border-[#424448] font-pretendard text-14 text-white w-auto"
-              >
-                {i}
-              </div>
-            );
-          })}
-        </div>
-      </div>
-    </div>
+      ) : null}
+    </>
   );
 };
 

--- a/src/feature/homepage/HomePageIntroContent.tsx
+++ b/src/feature/homepage/HomePageIntroContent.tsx
@@ -1,5 +1,6 @@
 import { useSearchStore } from '@/store/searchStore';
 import ui from '../../assets/homepage/ui-spoteditor.png';
+import CitySearchForm from './CitySearchForm';
 
 const HomePageIntroContent = () => {
   const category: string[] = [
@@ -16,17 +17,17 @@ const HomePageIntroContent = () => {
     <>
       {!isOpen ? (
         <div className="w-full flex pt-24 py-10 h-[387px] gap-7 bg-black px-50px">
-          <div className="w-[655px] flex flex-col gap-9 bg-red-300">
-            <div className="text-white font-pretendard text-32 font-500">
+          <div className="w-[655px] flex flex-col justify-between gap-9">
+            <div className="text-white font-pretendard text-28 font-500">
               반가워요!
               <br />
               Spoteditor는 <span className="font-semibold">"어디 가서 놀지?"</span> 하고 고민하는
               <br />
               여러분을 위해 만들어졌어요.
             </div>
-            <section className="w-full bg-blue-300"></section>
+            <CitySearchForm />
           </div>
-          <div className="w-[655px] flex flex-col gap-5">
+          <div className="w-[655px] flex flex-col gap-5 justify-between">
             <img src={ui} alt="ui_spoteditior_description" />
             <div className="flex flex-wrap gap-1.5">
               {category.map((i) => {

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,5 +1,4 @@
 import MainFooter from '../../components/Footer/MainFooter';
-import MainHeader from '../../components/Header/MainHeader';
 import HomePageIntroContent from '../../feature/homepage/HomePageIntroContent';
 import SortByLog from '../../feature/homepage/SortByLog';
 import SortByPopularity from '../../feature/homepage/SortByPopularity';

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,0 +1,158 @@
+import PageContentLayout from '@/components/Layout/PageContentLayout';
+import SectionHeader from '@/components/Header/SectionHeader';
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { Separator } from '@/components/ui/separator';
+import { cn } from '@/lib/utils';
+import CustomPagination from '@/components/CustomPagination';
+
+function Search() {
+  const location = useLocation();
+  const nav = useNavigate();
+  const title = location.state?.title || '';
+
+  useEffect(() => {
+    if (!title) {
+      nav('/');
+    }
+  }, [title, nav]);
+  return (
+    <PageContentLayout className="web:gap-[50px]">
+      <SectionHeader labelText="Searching for" queryText={title} bottomLine />
+      <SectionHeader labelText="Sort by" queryText="Popularity" />
+      {/* <SearchNotFound /> */}
+      <div className="w-full h-[1524px] ">
+        <div className="flex w-[156px] flex-col gap-4 mb-12">
+          <div className="font-untitled text-32 h-[23px] text-[#ABAFB5]">Sort by</div>
+          <div className="font-untitled text-32 h-[23px] text-[#242528]">Log</div>
+        </div>
+        <div className="flex w-full">
+          <div className="w-1/2  h-[1328px] flex flex-wrap">
+            <div className="w-[314px] mr-5">
+              <div className="w-full h-[218px] bg-red-100 mb-2"></div>
+              <div className="w-full font-bold text-black font-pretendard text-16">
+                혼자 보내는 하루, 골목골목 숨어있는 용산 원효로 카페
+              </div>
+              <div className="w-full font-pretendard text-17 font-normal text-[#ABAFB5]">
+                서울 | 위치 세부정보
+              </div>
+            </div>
+            <div className="w-[314px] mr-5">
+              <div className="w-full h-[218px] bg-red-100 mb-2"></div>
+              <div className="w-full font-bold text-black font-pretendard text-16">
+                혼자 보내는 하루, 골목골목 숨어있는 용산 원효로 카페
+              </div>
+              <div className="w-full font-pretendard text-17 font-normal text-[#ABAFB5]">
+                서울 | 위치 세부정보
+              </div>
+            </div>
+            <div className="w-[314px] mr-5">
+              <div className="w-full h-[218px] bg-red-100 mb-2"></div>
+              <div className="w-full font-bold text-black font-pretendard text-16">
+                혼자 보내는 하루, 골목골목 숨어있는 용산 원효로 카페
+              </div>
+              <div className="w-full font-pretendard text-17 font-normal text-[#ABAFB5]">
+                서울 | 위치 세부정보
+              </div>
+            </div>
+            <div className="w-[314px] mr-5">
+              <div className="w-full h-[218px] bg-red-100 mb-2"></div>
+              <div className="w-full font-bold text-black font-pretendard text-16">
+                혼자 보내는 하루, 골목골목 숨어있는 용산 원효로 카페
+              </div>
+              <div className="w-full font-pretendard text-17 font-normal text-[#ABAFB5]">
+                서울 | 위치 세부정보
+              </div>
+            </div>
+            <div className="w-[314px] mr-5">
+              <div className="w-full h-[218px] bg-red-100 mb-2"></div>
+              <div className="w-full font-bold text-black font-pretendard text-16">
+                혼자 보내는 하루, 골목골목 숨어있는 용산 원효로 카페
+              </div>
+              <div className="w-full font-pretendard text-17 font-normal text-[#ABAFB5]">
+                서울 | 위치 세부정보
+              </div>
+            </div>
+            <div className="w-[314px] mr-5">
+              <div className="w-full h-[218px] bg-red-100 mb-2"></div>
+              <div className="w-full font-bold text-black font-pretendard text-16">
+                혼자 보내는 하루, 골목골목 숨어있는 용산 원효로 카페
+              </div>
+              <div className="w-full font-pretendard text-17 font-normal text-[#ABAFB5]">
+                서울 | 위치 세부정보
+              </div>
+            </div>
+            <div className="w-[314px] mr-5">
+              <div className="w-full h-[218px] bg-red-100 mb-2"></div>
+              <div className="w-full font-bold text-black font-pretendard text-16">
+                혼자 보내는 하루, 골목골목 숨어있는 용산 원효로 카페
+              </div>
+              <div className="w-full font-pretendard text-17 font-normal text-[#ABAFB5]">
+                서울 | 위치 세부정보
+              </div>
+            </div>
+            <div className="w-[314px] mr-5">
+              <div className="w-full h-[218px] bg-red-100 mb-2"></div>
+              <div className="w-full font-bold text-black font-pretendard text-16">
+                혼자 보내는 하루, 골목골목 숨어있는 용산 원효로 카페
+              </div>
+              <div className="w-full font-pretendard text-17 font-normal text-[#ABAFB5]">
+                서울 | 위치 세부정보
+              </div>
+            </div>
+          </div>
+          <div className="w-1/2  h-[1328px] flex flex-wrap">
+            <div className="w-[664px] mr-5 mb-6">
+              <div className="w-full h-[550px] bg-red-100 mb-2"></div>
+              <div className="w-full font-bold text-black font-pretendard text-16">
+                혼자 보내는 하루, 골목골목 숨어있는 용산 원효로 카페
+              </div>
+              <div className="w-full font-pretendard text-17 font-normal text-[#ABAFB5]">
+                서울 | 위치 세부정보
+              </div>
+            </div>
+            <div className="w-[314px] mr-5">
+              <div className="w-full h-[218px] bg-red-100 mb-2"></div>
+              <div className="w-full font-bold text-black font-pretendard text-16">
+                혼자 보내는 하루, 골목골목 숨어있는 용산 원효로 카페
+              </div>
+              <div className="w-full font-pretendard text-17 font-normal text-[#ABAFB5]">
+                서울 | 위치 세부정보
+              </div>
+            </div>
+            <div className="w-[314px] mr-5">
+              <div className="w-full h-[218px] bg-red-100 mb-2"></div>
+              <div className="w-full font-bold text-black font-pretendard text-16">
+                혼자 보내는 하루, 골목골목 숨어있는 용산 원효로 카페
+              </div>
+              <div className="w-full font-pretendard text-17 font-normal text-[#ABAFB5]">
+                서울 | 위치 세부정보
+              </div>
+            </div>
+            <div className="w-[314px] mr-5">
+              <div className="w-full h-[218px] bg-red-100 mb-2"></div>
+              <div className="w-full font-bold text-black font-pretendard text-16">
+                혼자 보내는 하루, 골목골목 숨어있는 용산 원효로 카페
+              </div>
+              <div className="w-full font-pretendard text-17 font-normal text-[#ABAFB5]">
+                서울 | 위치 세부정보
+              </div>
+            </div>
+            <div className="w-[314px] mr-5">
+              <div className="w-full h-[218px] bg-red-100 mb-2"></div>
+              <div className="w-full font-bold text-black font-pretendard text-16">
+                혼자 보내는 하루, 골목골목 숨어있는 용산 원효로 카페
+              </div>
+              <div className="w-full font-pretendard text-17 font-normal text-[#ABAFB5]">
+                서울 | 위치 세부정보
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <CustomPagination current={2} total={12} />
+    </PageContentLayout>
+  );
+}
+
+export default Search;

--- a/src/store/searchStore.ts
+++ b/src/store/searchStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface SearchState {
+  isOpen: boolean;
+  toggleSearchBar: () => void;
+}
+
+export const useSearchStore = create<SearchState>((set) => ({
+  isOpen: false,
+  toggleSearchBar: () => set((state) => ({ isOpen: !state.isOpen })),
+}));

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,7 @@ module.exports = {
     extend: {
       screens: {
         mobile: { max: '768px' }, // 480px ~ 768px
-        web: '769px', // 769px 이상
+        web: '769px', // 769px 이상,
       },
       spacing: {
         '50px': '50px',


### PR DESCRIPTION
## 작업 주제

- 검색바 토글 기능 추가 및 UI 개선
- 검색 결과를 보여주는 Search 페이지 추가
- 홈페이지 인트로 콘텐츠 내 도시 검색 섹션 추가 및 레이아웃 일부 수정

## 작업 내용

 - 메인 헤더에 검색바 토글 기능 추가
   - 검색 아이콘 클릭 시 검색바를 토글할 수 있도록 기능 추가
   - 검색바가 열리면 HomePageIntroContent가 자동으로 숨겨지도록 설정
   - 검색바가 활성화될 때 보여질 반투명 오버레이 화면 추가
 - 검색 결과를 보여주는 Search 페이지 추가
 - 홈페이지 인트로에 도시 검색 섹션 추가 및 레이아웃 수정
   - 사용자가 특정 도시나 지역을 검색할 수 있도록 도시 검색 섹션 추가
   - 기존 인트로 콘텐츠 내부 요소들의 레이아웃을 일부 조정하여 UI 개선

## 추가 사항
 - 도시 검색 섹션의 일부 css는 추후 샤드cn의 Form 컴포넌트로 교체하며 수정할 예정

@gunyongbok 확인 부탁드립니다
