### PR TITLE
공지사항 관련 페이지 추가 및 반응형 수정

### DIFF
--- a/src/components/Header/MainHeader/MainHeader.tsx
+++ b/src/components/Header/MainHeader/MainHeader.tsx
@@ -10,7 +10,7 @@ const MainHeader = () => {
   const { toggleSearchBar } = useSearchStore();
 
   return (
-    <header className="fixed w-full z-50 bg-black web:px-[50px] mobile:px-4 web:py-5 mobile:py-[14px] web:min-w-[1440px] flex justify-center flex-col left-0 top-0">
+    <header className="sticky w-full z-50 bg-black web:px-[50px] mobile:px-4 web:py-5 mobile:py-[14px] web:min-w-[1440px] flex justify-center flex-col left-0 top-0">
       <section className="flex justify-between w-full">
         <Link to="/">
           <LogoIcon className="text-white w-[120px] h-5 cursor-pointer" fill="white" />

--- a/src/components/Header/MainHeader/MainHeader.tsx
+++ b/src/components/Header/MainHeader/MainHeader.tsx
@@ -3,26 +3,30 @@ import search from '@/assets/homepage/search.png';
 import LogoIcon from '@/components/Icons/LogoIcon';
 import { useSearchStore } from '@/store/searchStore';
 import { Link } from 'react-router-dom';
-import LoginStatusButtons from './LoginStatusButtons';
 import LoginModal from '@/features/login/LoginModal';
+import SearchBar from '@/features/search/SearchBar';
+import LoginStatusButtons from '@/components/Header/MainHeader/LoginStatusButtons';
 const MainHeader = () => {
   const { toggleSearchBar } = useSearchStore();
 
   return (
-    <header className="w-full bg-black px-4 py-5 web:px-[50px] flex justify-between items-center">
-      <Link to="/">
-        <LogoIcon className="text-white w-[120px] h-5 cursor-pointer" fill="white" />
-      </Link>
-
-      <section className="flex web:gap-[46px] mobile:gap-[20px] items-center justify-between text-white">
-        <button onClick={toggleSearchBar}>
-          <img src={search} alt="search_logo" className="object-contain w-[20px] h-[20px]" />
-        </button>
-        <button>
-          <img src={global} alt="global_logo" className="object-contain w-[20px] h-[20px]" />
-        </button>
-        <LoginStatusButtons />
+    <header className="fixed w-full z-50 bg-black web:px-[50px] mobile:px-4 web:py-5 mobile:py-[14px] web:min-w-[1440px] flex justify-center flex-col left-0 top-0">
+      <section className="flex justify-between w-full">
+        <Link to="/">
+          <LogoIcon className="text-white w-[120px] h-5 cursor-pointer" fill="white" />
+        </Link>
+        <section className="flex web:gap-[46px] mobile:gap-[20px] items-center justify-between text-white">
+          <button onClick={toggleSearchBar}>
+            <img src={search} alt="search_logo" className="object-contain w-[20px] h-[20px]" />
+          </button>
+          <button>
+            <img src={global} alt="global_logo" className="object-contain w-[20px] h-[20px]" />
+          </button>
+          <LoginStatusButtons />
+        </section>
       </section>
+
+      <SearchBar />
 
       <LoginModal />
     </header>

--- a/src/components/Header/MainHeader/UserProfileButton.tsx
+++ b/src/components/Header/MainHeader/UserProfileButton.tsx
@@ -48,7 +48,7 @@ function UserProfileButton() {
         </DropdownMenuItem>
         <Link to="/profile/12/my-logs">
           <DropdownMenuItem className="px-4 py-5 focus:bg-white">
-            <Button className="w-full h-full rounded-[60px] bg-[#F7F7F7] text-text-sm font-medium hover:bg-[#F7F7F7]">
+            <Button className="w-full h-full rounded-[60px] bg-[#F7F7F7] text-black font-medium hover:bg-[#F7F7F7]">
               프로필 보기
             </Button>
           </DropdownMenuItem>

--- a/src/components/Header/MainHeader/UserProfileButton.tsx
+++ b/src/components/Header/MainHeader/UserProfileButton.tsx
@@ -48,8 +48,8 @@ function UserProfileButton() {
         </DropdownMenuItem>
         <Link to="/profile/12/my-logs">
           <DropdownMenuItem className="px-4 py-5 focus:bg-white">
-            <Button className="w-full h-full rounded-[60px] bg-[#F7F7F7] text-black font-medium hover:bg-[#F7F7F7]">
-              프로필 보기
+            <Button className="w-full h-full rounded-[60px] bg-[#F7F7F7] hover:bg-[#F7F7F7]">
+              <span className="font-medium text-black text-text-sm">프로필 보기</span>
             </Button>
           </DropdownMenuItem>
         </Link>

--- a/src/components/Header/MainHeader/UserProfileButton.tsx
+++ b/src/components/Header/MainHeader/UserProfileButton.tsx
@@ -33,7 +33,7 @@ function UserProfileButton() {
   }, []);
 
   return (
-    <DropdownMenu>
+    <DropdownMenu modal={false}>
       <DropdownMenuTrigger className="focus:outline-none" asChild>
         <button>
           <UserIcon />

--- a/src/components/Header/MainHeader/UserProfileButton.tsx
+++ b/src/components/Header/MainHeader/UserProfileButton.tsx
@@ -39,7 +39,7 @@ function UserProfileButton() {
           <UserIcon />
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent className="w-[230px]">
+      <DropdownMenuContent>
         <DropdownMenuItem className="font-bold text-text-lg flex justify-start gap-[5px] px-4 items-center">
           <span ref={textRef} className="truncate">
             Teamspoteditor
@@ -54,25 +54,31 @@ function UserProfileButton() {
           </DropdownMenuItem>
         </Link>
         <DropdownMenuSeparator />
-        <Link to="/profile-setting">
-          <DropdownMenuItem className="flex items-center justify-start gap-2 text-text-sm">
-            <SettingIcon />
-            설정
+        <div className="m-1">
+          <Link to="/profile-setting">
+            <DropdownMenuItem className="flex items-center justify-start gap-2 px-4 py-3 text-text-sm">
+              <SettingIcon />
+              설정
+            </DropdownMenuItem>
+          </Link>
+          <DropdownMenuItem className="flex items-center justify-start gap-2 px-4 py-3 text-text-sm">
+            <HeadPhoneIcon />
+            문의하기
           </DropdownMenuItem>
-        </Link>
+        </div>
         <DropdownMenuSeparator />
-        <DropdownMenuItem className="flex items-center justify-start gap-2 text-text-sm">
-          <HeadPhoneIcon />
-          고객센터
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem asChild className="flex items-center justify-start gap-2 text-text-sm">
-          <LogoutButton />
-        </DropdownMenuItem>
+        <div className="m-1">
+          <DropdownMenuItem asChild className="flex items-center justify-start text-text-sm">
+            <LogoutButton />
+          </DropdownMenuItem>
+        </div>
         <DropdownMenuSeparator />
         <div className="flex items-center justify-start px-4 py-[10px] gap-[15px] text-[#81858F]">
+          <Link to="/notice" className="flex">
+            <button className="text-text-xs">공지사항</button>
+          </Link>
           <button className="text-text-xs">이용약관</button>
-          <button className="text-text-xs">개인 정보 처리방침</button>
+          <button className="text-text-xs">개인정보처리방침</button>
         </div>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/components/Icons/LeftArrowIcon.tsx
+++ b/src/components/Icons/LeftArrowIcon.tsx
@@ -1,0 +1,29 @@
+import { SVGProps } from 'react';
+
+function LeftArrowIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 25"
+      fill="none"
+      {...props}
+    >
+      <g clip-path="url(#clip0_6525_9658)">
+        <path
+          d="M9.5 4.21484L1 12.7148M1 12.7148L9.5 21.2148M1 12.7148H17.5"
+          stroke="black"
+          strokeWidth="1.5"
+        />
+      </g>
+      <defs>
+        <clipPath id="clip0_6525_9658">
+          <rect width="24" height="24" fill="white" transform="translate(0 0.714844)" />
+        </clipPath>
+      </defs>
+    </svg>
+  );
+}
+
+export default LeftArrowIcon;

--- a/src/components/Icons/SettingIcon.tsx
+++ b/src/components/Icons/SettingIcon.tsx
@@ -11,8 +11,8 @@ function SettingIcon() {
         <path
           d="M7 9.04036C7.9665 9.04036 8.75 8.25686 8.75 7.29036C8.75 6.32387 7.9665 5.54036 7 5.54036C6.0335 5.54036 5.25 6.32387 5.25 7.29036C5.25 8.25686 6.0335 9.04036 7 9.04036Z"
           stroke="#09090B"
-          stroke-linecap="round"
-          stroke-linejoin="round"
+          strokeLinecap="round"
+          strokeLinejoin="round"
         />
       </g>
       <defs>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 import XIcon from '../Icons/XIcon';
-import { X } from 'lucide-react';
 
 const Dialog = DialogPrimitive.Root;
 

--- a/src/features/login/LoginModal.tsx
+++ b/src/features/login/LoginModal.tsx
@@ -18,7 +18,10 @@ function LoginModal() {
     /* onClose(): 모달이 닫힐 때 호출되어 open을 false로 변경 */
     <Dialog open={isOpen} onOpenChange={(open) => !open && closeLoginModal()} modal={true}>
       <DialogPrimitive.Overlay className=" mobile:bg-white" />
-      <DialogContent className="mobile:top-0 mobile:left-[50%] mobile:w-[375px] mobile:translate-x-[-50%] mobile:translate-y-0">
+      <DialogContent
+        hideCloseButton
+        className="mobile:top-0 mobile:left-[50%] mobile:w-[375px] mobile:translate-x-[-50%] mobile:translate-y-0 web:pb-[44.82px]"
+      >
         <DialogClose
           asChild
           className="flex items-center justify-end w-full web:py-2 mobile:py-[13px]"
@@ -36,7 +39,7 @@ function LoginModal() {
               <br /> 업데이트 소식을 확인해보세요.
             </DialogDescription>
           </DialogHeader>
-          <Button size="icon" variant="ghost" className="w-auto web:my-5 mobile:my-10">
+          <Button variant={null} className="w-auto web:my-5 mobile:my-10">
             <img className="object-contain" src={kakaoLoginButton} alt="카카오 로그인 버튼" />
           </Button>
           <p className="text-text-xs text-center text-[#6D727D] w-[320px]">

--- a/src/features/notice/NoticeHeader.tsx
+++ b/src/features/notice/NoticeHeader.tsx
@@ -1,0 +1,20 @@
+import LeftArrowIcon from '@/components/Icons/LeftArrowIcon';
+import { useNavigate } from 'react-router-dom';
+
+interface NoticeHeaderProps {
+  title: string;
+}
+
+function NoticeHeader({ title }: NoticeHeaderProps) {
+  const nav = useNavigate();
+  return (
+    <header className="w-full bg-white flex justify-start items-center sticky web:top-[60px] mobile:top-12 gap-2.5 pt-3 pb-2.5 border-b-[1px] border-b-primary-50">
+      <button onClick={() => nav(-1)}>
+        <LeftArrowIcon className="ml-4" />
+      </button>
+      <h2 className="font-bold text-text-2xl">{title}</h2>
+    </header>
+  );
+}
+
+export default NoticeHeader;

--- a/src/features/notice/notice-detail/NoticeDetailContent.tsx
+++ b/src/features/notice/notice-detail/NoticeDetailContent.tsx
@@ -1,0 +1,13 @@
+interface NoticeDetailContentProps {
+  content: string;
+}
+
+function NoticeDetailContent({ content }: NoticeDetailContentProps) {
+  return (
+    <section className="flex px-4 py-2.5">
+      <span className="font-medium leading-6 text-[14px] text-primary-600">{content}</span>
+    </section>
+  );
+}
+
+export default NoticeDetailContent;

--- a/src/features/notice/notice-detail/NoticeDetailHeader.tsx
+++ b/src/features/notice/notice-detail/NoticeDetailHeader.tsx
@@ -1,0 +1,27 @@
+import LeftArrowIcon from '@/components/Icons/LeftArrowIcon';
+import { useNavigate } from 'react-router-dom';
+
+interface NoticeDetailHeaderProps {
+  title: string;
+  time: string;
+}
+
+function NoticeDetailHeader({ title, time }: NoticeDetailHeaderProps) {
+  const nav = useNavigate();
+
+  return (
+    <header className="w-full bg-white sticky web:top-[60px] mobile:top-12 border-b-[1px] border-b-primary-50 flex flex-col">
+      <div className="flex w-full pt-3 border-b-[1px] border-b-primary-50 flex-start ">
+        <button onClick={() => nav(-1)}>
+          <LeftArrowIcon className="ml-4 my-3.5" />
+        </button>
+      </div>
+      <div className="w-full pt-[15px] px-4 flex flex-col justify-center items-start gap-1">
+        <h2 className="font-bold text-text-2xl">{title}</h2>
+        <time className="text-text-xs text-primary-400">{time}</time>
+      </div>
+    </header>
+  );
+}
+
+export default NoticeDetailHeader;

--- a/src/features/notice/notice-detail/NoticeDetailInfo.tsx
+++ b/src/features/notice/notice-detail/NoticeDetailInfo.tsx
@@ -1,0 +1,15 @@
+interface NoticeDetailInfoProps {
+  title: string;
+  content: string;
+}
+
+function NoticeDetailInfo({ title, content }: NoticeDetailInfoProps) {
+  return (
+    <div className="flex flex-col gap-[7px]">
+      <h3 className="font-bold text-text-lg">{title}</h3>
+      <span className="text-text-sm text-primary-600">{content}</span>
+    </div>
+  );
+}
+
+export default NoticeDetailInfo;

--- a/src/features/profile/FollowButton.tsx
+++ b/src/features/profile/FollowButton.tsx
@@ -26,7 +26,10 @@ function FollowButton({ label, count }: FollowButtonProps) {
           <span className="font-bold text-center text-[18px]">{count}</span>
         </button>
       </DialogTrigger>
-      <DialogContent className="web:w-[348px] mobile:w-[340px] h-420 p-0 overflow-hidden">
+      <DialogContent
+        hideCloseButton
+        className="web:w-[348px] mobile:w-[340px] h-420 p-0 overflow-hidden"
+      >
         <DialogTitle className="grid grid-cols-3 w-full mb-2 section-heading h-[50px] px-2.5">
           <div />
           <div className="flex items-center justify-center">
@@ -58,7 +61,10 @@ function FollowButton({ label, count }: FollowButtonProps) {
                 <figcaption className="font-bold text-text-xs">user name</figcaption>
               </figure>
               {label === '팔로잉' && (
-                <Button variant="secondary" className="font-medium h-7 w-[62px] rounded-[60px]">
+                <Button
+                  variant="ghost"
+                  className="font-medium h-7 w-[62px] rounded-[60px] text-text-xs"
+                >
                   팔로잉
                 </Button>
               )}

--- a/src/features/profile/LogoutButton.tsx
+++ b/src/features/profile/LogoutButton.tsx
@@ -13,7 +13,7 @@ function LogoutButton() {
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <button className="flex items-center cursor-default justify-start gap-2 text-[14px] rounded-sm px-2 py-1.5 w-full hover:bg-neutral-100 focus:bg-neutral-100 focus:text-neutral-900">
+        <button className="flex items-center cursor-default justify-start gap-2 text-[14px] rounded-sm px-4 py-3 w-full hover:bg-neutral-100 focus:bg-neutral-100 focus:text-neutral-900">
           <LogoutIcon />
           <p>로그아웃</p>
         </button>

--- a/src/features/search/SearchBar.tsx
+++ b/src/features/search/SearchBar.tsx
@@ -4,7 +4,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Input } from '@/components/ui/input';
 import { useNavigate } from 'react-router-dom';
-import SearchIcon from '../../components/Icons/SearchIcon';
+import SearchIcon from '@/components/Icons/SearchIcon';
 import { useSearchStore } from '@/store/searchStore';
 
 function SearchBar() {
@@ -36,7 +36,7 @@ function SearchBar() {
     <>
       {isOpen ? (
         <>
-          <nav className="web:px-[50px] z-40 py-[30px] sticky mobile:px-4 web:w-[1440px] mobile:w-full flex justify-center items-center bg-black">
+          <nav className="web:px-[50px] -z-10 py-[30px] sticky mobile:px-4 w-full flex justify-center items-center bg-black">
             <Form {...form}>
               <form
                 onSubmit={form.handleSubmit(onSearchSubmit)}
@@ -67,7 +67,7 @@ function SearchBar() {
           </nav>
           <div
             onClick={onCloseOverlayClick}
-            className="fixed z-30 w-full h-screen web:w-[1440px] mobile:w-full bg-black/80"
+            className="fixed top-0 left-0 w-screen h-screen -z-20 bg-black/80"
           />
         </>
       ) : null}

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -4,7 +4,7 @@ import MainHeader from '../components/Header/MainHeader/MainHeader';
 
 const MainLayout = () => {
   return (
-    <div className="flex flex-col items-center h-screen web:min-w-[1440px] web:pt-[60px] mobile:pt-10">
+    <div className="flex flex-col items-center h-auto min-h-screen web:min-w-[1440px] w-full">
       <MainHeader />
       <div className="w-full grow">
         <Outlet />

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,13 +1,11 @@
 import MainFooter from '@/components/Footer/MainFooter';
 import { Outlet } from 'react-router-dom';
 import MainHeader from '../components/Header/MainHeader/MainHeader';
-import SearchBar from '@/features/search/SearchBar';
 
 const MainLayout = () => {
   return (
-    <div className="flex flex-col items-center h-screen min-w-[480px] mx-auto web:w-[1440px]">
+    <div className="flex flex-col items-center h-screen web:min-w-[1440px] web:pt-[60px] mobile:pt-10">
       <MainHeader />
-      <SearchBar />
       <div className="w-full grow">
         <Outlet />
       </div>

--- a/src/pages/notice/index.tsx
+++ b/src/pages/notice/index.tsx
@@ -1,0 +1,26 @@
+import NoticeHeader from '@/features/notice/NoticeHeader';
+
+function Notice() {
+  return (
+    <div className="flex justify-center w-full">
+      <div className="max-w-[724px] w-full">
+        <NoticeHeader title="공지사항" />
+        <section className="flex flex-col w-full">
+          {Array.from({ length: 7 }).map((_, idx) => (
+            <article
+              key={idx}
+              className="w-full px-4 py-5 gap-[3px] flex flex-col border-b-[1px] border-b-primary-50 hover:cursor-pointer"
+            >
+              <h3 className="font-medium text-text-sm">
+                스팟에디터 ‘서비스 이용약관’ 변경에 대한 안내
+              </h3>
+              <time className="text-text-xs text-primary-400">2025.03.15</time>
+            </article>
+          ))}
+        </section>
+      </div>
+    </div>
+  );
+}
+
+export default Notice;

--- a/src/pages/notice/index.tsx
+++ b/src/pages/notice/index.tsx
@@ -1,6 +1,8 @@
 import NoticeHeader from '@/features/notice/NoticeHeader';
+import { useNavigate } from 'react-router-dom';
 
 function Notice() {
+  const nav = useNavigate();
   return (
     <div className="flex justify-center w-full">
       <div className="max-w-[724px] w-full">
@@ -9,6 +11,7 @@ function Notice() {
           {Array.from({ length: 7 }).map((_, idx) => (
             <article
               key={idx}
+              onClick={() => nav(`${idx}`)}
               className="w-full px-4 py-5 gap-[3px] flex flex-col border-b-[1px] border-b-primary-50 hover:cursor-pointer"
             >
               <h3 className="font-medium text-text-sm">

--- a/src/pages/notice/notice-detail/index.tsx
+++ b/src/pages/notice/notice-detail/index.tsx
@@ -1,0 +1,34 @@
+import NoticeDetailContent from '@/features/notice/notice-detail/NoticeDetailContent';
+import NoticeDetailHeader from '@/features/notice/notice-detail/NoticeDetailHeader';
+import NoticeDetailInfo from '@/features/notice/notice-detail/NoticeDetailInfo';
+
+function NoticeDetail() {
+  return (
+    <div className="flex justify-center w-full h-[1000vh]">
+      <div className="max-w-[724px] w-full">
+        <NoticeDetailHeader
+          title="스팟에디터 ‘서비스 이용약관’ 변경에 
+대한 안내"
+          time="2025.03.15"
+        />
+        <NoticeDetailContent
+          content="안녕하세요. 스팟에디터 팀입니다. 스팟에디터를 이용해주시는 회원 여러분께 진심으로
+        감사드리며, 스팟에디터 ‘서비스 이용약관’ 변경에 관한 안내 말씀 드립니다. 아래의 ‘서비스
+        이용약관’ 변경사항을 확인하시고, 서비스 이용에 참고 부탁 드리겠습니다."
+        />
+        <section className="flex px-4 py-2.5 flex-col gap-5">
+          <NoticeDetailInfo
+            title="변경 일자"
+            content="변경된 ‘서비스 이용약관’은 2025년 3월 30일 자로 효력이 발생됩니다."
+          />
+          <NoticeDetailInfo
+            title="변경 내용"
+            content="이메일 주소 변경에 다른 서비스 이용약관 개정"
+          />
+        </section>
+      </div>
+    </div>
+  );
+}
+
+export default NoticeDetail;

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -1,6 +1,8 @@
 import MainLayout from '@/layouts/MainLayout';
 import DetailPage from '@/pages/detail';
 import HomePage from '@/pages/home';
+import Notice from '@/pages/notice';
+import NoticeDetail from '@/pages/notice/notice-detail';
 import Profile from '@/pages/profile';
 import ProfileSetting from '@/pages/profile-setting';
 import MyLogs from '@/pages/profile/my-logs';
@@ -41,6 +43,10 @@ const router = createBrowserRouter([
       {
         path: 'notice',
         element: <Notice />,
+      },
+      {
+        path: 'notice/:noticeId',
+        element: <NoticeDetail />,
       },
     ],
   },

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -38,6 +38,10 @@ const router = createBrowserRouter([
         path: 'profile-setting',
         element: <ProfileSetting />,
       },
+      {
+        path: 'notice',
+        element: <Notice />,
+      },
     ],
   },
 ]);


### PR DESCRIPTION
## 📌 작업 주제

- 공지사항, 공지사항 상세 페이지 추가
- 드래그 시 헤더 상단에 고정
- 메인 레이아웃 반응형 수정

## 🛠 작업 내용

- 공지사항 관련 페이지 추가
- 반응형 수정
-   - 기존: 
    - 웹: width 1440px 고정
  - 수정: 
    - 웹: 최소 width 1440px, 브라우저의 크기가 1440px이 넘어가면 그에 따라 증가
- sticky 속성을 이용하여 드래그 시 헤더 상단에 고정
  - fixed는 화면(뷰포트) 기준으로 동작하여 모달창 렌더링 시 스크롤바가 사라지면 그만큼 헤더만 늘어나는 버그 발생
  - 부모 요소 기준으로 동작하는 sticky 속성으로 대체하여 사라진 스크롤바만큼 헤더가 늘어나는 현상 해결
