### PR TITLE
프로필 설정 페이지 리팩토링 및 이미지 업로드 기능 추가

### DIFF
--- a/src/components/Header/MainHeader/UserProfileButton.tsx
+++ b/src/components/Header/MainHeader/UserProfileButton.tsx
@@ -55,7 +55,7 @@ function UserProfileButton() {
         </Link>
         <DropdownMenuSeparator />
         <div className="m-1">
-          <Link to="/profile-setting">
+          <Link to="">
             <DropdownMenuItem className="flex items-center justify-start gap-2 px-4 py-3 text-text-sm">
               <SettingIcon />
               설정

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -72,7 +72,7 @@ const FormItem = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivEl
 
     return (
       <FormItemContext.Provider value={{ id }}>
-        <div ref={ref} className={cn('space-y-2', className)} {...props} />
+        <div ref={ref} className={cn(className)} {...props} />
       </FormItemContext.Provider>
     );
   }
@@ -146,7 +146,7 @@ const FormMessage = React.forwardRef<
     <p
       ref={ref}
       id={formMessageId}
-      className={cn('text-sm font-medium text-red-500', className)}
+      className={cn('text-text-xs font-medium text-red-500', className)}
       {...props}
     >
       {body}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
       <input
         type={type}
         className={cn(
-          'flex h-10 w-full bg-white px-3 py-2 text-base file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-neutral-950 placeholder:text-neutral-500 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+          'flex w-full bg-white px-3 py-2 text-base file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-neutral-950 placeholder:text-neutral-500 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
           className
         )}
         ref={ref}

--- a/src/features/profile-setting/AccountSettings.tsx
+++ b/src/features/profile-setting/AccountSettings.tsx
@@ -2,7 +2,7 @@ import DeleteAccountConfirmButton from '@/features/profile-setting/DeleteAccount
 
 export default function AccountSettings() {
   return (
-    <section>
+    <section className="mt-10">
       <p className="mb-4 font-bold text-text-lg web:text-text-2xl">계정 설정</p>
       <div className="flex items-center justify-between py-[5px]">
         <p className="form-label">계정 삭제</p>

--- a/src/features/profile-setting/AccountSettings.tsx
+++ b/src/features/profile-setting/AccountSettings.tsx
@@ -1,0 +1,17 @@
+import DeleteAccountConfirmButton from '@/features/profile-setting/DeleteAccountConfirmButton';
+
+export default function AccountSettings() {
+  return (
+    <section>
+      <p className="mb-4 font-bold text-text-lg web:text-text-2xl">계정 설정</p>
+      <div className="flex items-center justify-between py-[5px]">
+        <p className="form-label">계정 삭제</p>
+        <DeleteAccountConfirmButton />
+      </div>
+      <p className="font-medium text-primarySlate text-text-xs">
+        계정 삭제시 등록된 로그는 삭제되지 않습니다. <br /> 로그를 삭제하시려면 개별 삭제를
+        해주세요.
+      </p>
+    </section>
+  );
+}

--- a/src/features/profile-setting/DeleteAccountConfirmButton.tsx
+++ b/src/features/profile-setting/DeleteAccountConfirmButton.tsx
@@ -17,11 +17,7 @@ function DeleteAccountConfirmButton() {
       <DialogContent hideCloseButton className="web:w-[390px] mobile:w-[300px] p-6">
         <DialogTitle className="w-full mb-2 section-heading">계정삭제</DialogTitle>
         <DialogDescription className="text-text-xs text-[#6D727D] text-start w-full mb-4">
-          계정 삭제시 등록된 로그는 삭제되지 않습니다.
-          <br />
-          로그를 삭제하시려면 개별 삭제를 해주세요.
-          <br />
-          이외 정보는 영구삭제 됩니다.
+          계정 삭제가 완료 되었습니다.
         </DialogDescription>
         <DialogClose asChild className="flex justify-end w-full">
           <div className="space-x-[15px]">

--- a/src/features/profile-setting/ProfileSettingAvatar.tsx
+++ b/src/features/profile-setting/ProfileSettingAvatar.tsx
@@ -1,0 +1,41 @@
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Input } from '@/components/ui/input';
+import PenIcon from '@/components/Icons/PenIcon';
+import useImagePreview from '@/hooks/useImagePreview';
+import { useRef } from 'react';
+
+interface ProfileSettingAvatarProps {
+  imageUrl: string;
+}
+
+export default function ProfileSettingAvatar({ imageUrl }: ProfileSettingAvatarProps) {
+  const hiddenInputRef = useRef<HTMLInputElement>(null);
+  const handleImageClick = () => hiddenInputRef.current?.click();
+  const { imagePreview, handleFileChange } = useImagePreview(imageUrl);
+
+  return (
+    <div className="flex justify-center ">
+      <article className="relative">
+        <Avatar className="w-[100px] h-[100px] relative">
+          <AvatarImage src={imagePreview} alt="프로필 이미지" />
+          <AvatarFallback>CN</AvatarFallback>
+        </Avatar>
+        <button
+          type="button"
+          onClick={handleImageClick}
+          className="absolute bottom-0 right-0 flex justify-center items-center w-[26px] h-[26px] bg-white z-10 rounded-full border border-[#E5E6E8]"
+        >
+          <PenIcon className="w-4 h-4 stroke-black" />
+        </button>
+        <Input
+          type="file"
+          accept="image/*"
+          id="imageUrl"
+          ref={hiddenInputRef}
+          onChange={handleFileChange}
+          className="hidden"
+        />
+      </article>
+    </div>
+  );
+}

--- a/src/features/profile-setting/ProfileSettingForm.tsx
+++ b/src/features/profile-setting/ProfileSettingForm.tsx
@@ -1,0 +1,85 @@
+import { FormControl, FormField, FormItem, FormLabel } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+import { useFormContext } from 'react-hook-form';
+
+export default function ProfileSettingForm() {
+  //useFormContext을 이용해 부모 컴포넌트의 useForm 데이터를 사용
+  const { control, watch } = useFormContext();
+  const { name: nameLeng, description: descLeng } = watch();
+
+  return (
+    <section className="flex flex-col gap-5">
+      <FormField
+        control={control}
+        name="name"
+        render={({ field }) => (
+          <FormItem className="border-b-[1px] border-b-primary-100">
+            <div className="flex items-center justify-between py-[5px]">
+              <FormLabel className="font-bold text-text-sm">닉네임</FormLabel>
+              <span
+                className={cn(
+                  'text-text-2xs',
+                  nameLeng.length > 30 ? 'text-red-500' : 'text-primarySlate'
+                )}
+              >
+                {nameLeng.length}/30
+              </span>
+            </div>
+            <FormControl>
+              <Input
+                {...field}
+                placeholder="유저의 현재 닉네임"
+                className="text-text-sm placeholder:text-text-sm py-[5px]"
+              />
+            </FormControl>
+          </FormItem>
+        )}
+      />
+      <FormField
+        control={control}
+        name="description"
+        render={({ field }) => (
+          <FormItem className="border-b-[1px] border-b-primary-100">
+            <div className="flex items-center justify-between py-[5px]">
+              <FormLabel className="font-bold text-text-sm">프로필 설명</FormLabel>
+              <span
+                className={cn(
+                  'text-text-2xs',
+                  descLeng.length > 50 ? 'text-red-500' : 'text-primarySlate'
+                )}
+              >
+                {descLeng.length}/50
+              </span>
+            </div>
+            <FormControl>
+              <Input
+                {...field}
+                placeholder="프로필 설명을 입력하세요."
+                className="text-text-sm placeholder:text-text-sm py-[5px]"
+              />
+            </FormControl>
+          </FormItem>
+        )}
+      />
+      <FormField
+        control={control}
+        name="instagramId"
+        render={({ field }) => (
+          <FormItem className="border-b-[1px] border-b-primary-100">
+            <div className="flex items-center justify-start py-[5px]">
+              <FormLabel className="font-bold text-text-sm">인스타그램</FormLabel>
+            </div>
+            <FormControl>
+              <Input
+                {...field}
+                placeholder="@"
+                className="text-text-sm placeholder:text-text-sm py-[5px]"
+              />
+            </FormControl>
+          </FormItem>
+        )}
+      />
+    </section>
+  );
+}

--- a/src/features/profile-setting/SaveProfileButton.tsx
+++ b/src/features/profile-setting/SaveProfileButton.tsx
@@ -8,11 +8,24 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog';
 
-function SaveProfileButton() {
+interface SaveProfileButtonProps {
+  onTrigger?: () => void;
+}
+
+function SaveProfileButton({ onTrigger }: SaveProfileButtonProps) {
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Button className="rounded-[6px] w-[120px] h-[42px]">저장</Button>
+        <Button
+          onClick={() => {
+            if (onTrigger) {
+              onTrigger();
+            }
+          }}
+          className="rounded-[6px] w-[120px] h-[42px]"
+        >
+          저장
+        </Button>
       </DialogTrigger>
       <DialogContent className="web:w-[390px] mobile:w-[300px] p-6">
         <DialogTitle className="w-full mb-2 section-heading">저장이 완료 되었습니다.</DialogTitle>

--- a/src/features/profile-setting/SaveProfileButton.tsx
+++ b/src/features/profile-setting/SaveProfileButton.tsx
@@ -7,6 +7,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
+import { Link } from 'react-router-dom';
 
 interface SaveProfileButtonProps {
   onTrigger?: () => void;
@@ -27,17 +28,16 @@ function SaveProfileButton({ onTrigger }: SaveProfileButtonProps) {
           저장
         </Button>
       </DialogTrigger>
-      <DialogContent className="web:w-[390px] mobile:w-[300px] p-6">
+      <DialogContent hideCloseButton className="web:w-[390px] mobile:w-[300px] p-6">
         <DialogTitle className="w-full mb-2 section-heading">저장이 완료 되었습니다.</DialogTitle>
         <DialogDescription className="text-text-xs text-[#6D727D] text-start w-full mb-4">
           수정된 프로필 정보가 저장되었습니다.
         </DialogDescription>
         <DialogClose asChild className="flex justify-end w-full">
           <div className="space-x-[15px]">
-            <Button variant="outline" className="w-[53px]">
-              닫기
-            </Button>
-            <Button className="w-[91px]">확인</Button>
+            <Link to="/">
+              <Button className="w-[91px]">확인</Button>
+            </Link>
           </div>
         </DialogClose>
       </DialogContent>

--- a/src/features/profile/LogoutButton.tsx
+++ b/src/features/profile/LogoutButton.tsx
@@ -25,10 +25,10 @@ function LogoutButton() {
         </DialogDescription>
         <DialogClose asChild className="flex justify-end w-full">
           <div className="space-x-[15px]">
-            <Button variant="outline" className="w-[53px]">
-              닫기
+            <Button variant="outline" className="w-[80px]">
+              취소
             </Button>
-            <Button className="w-[91px]">확인</Button>
+            <Button className="w-[100px]">확인</Button>
           </div>
         </DialogClose>
       </DialogContent>

--- a/src/features/profile/ProfileHeader.tsx
+++ b/src/features/profile/ProfileHeader.tsx
@@ -3,6 +3,7 @@ import { Avatar, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import FollowButton from './FollowButton';
+import { Link } from 'react-router-dom';
 
 function ProfileHeader() {
   return (
@@ -30,12 +31,14 @@ function ProfileHeader() {
         </h3>
         <h3>@spoteditorofficial</h3>
       </section>
-      <Button
-        variant="outline"
-        className="web:mt-[15px] p-2 mobile:mt-[10px] web:w-[60px] web:h-[28px] mobile:w-[50px] mobile:h-[24px] rounded-[60px] font-medium text-text-xs"
-      >
-        편집
-      </Button>
+      <Link to="/profile-setting">
+        <Button
+          variant="outline"
+          className="web:mt-[15px] p-2 mobile:mt-[10px] web:w-[60px] web:h-[28px] mobile:w-[50px] mobile:h-[24px] rounded-[60px] font-medium text-text-xs"
+        >
+          편집
+        </Button>
+      </Link>
     </section>
   );
 }

--- a/src/hooks/useImagePreview.tsx
+++ b/src/hooks/useImagePreview.tsx
@@ -1,0 +1,50 @@
+import { useState, useEffect } from 'react';
+
+function useImagePreview(initialImageUrl: string = '') {
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [imagePreview, setImagePreview] = useState<string>(initialImageUrl);
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      setImageFile(file);
+    } else {
+      //이미지가 이미 있을 때 이미지를 새로 선택 안 할 경우 취소
+      setImageFile(null); // 메모리 해제
+      setImagePreview(initialImageUrl);
+    }
+  };
+
+  //이미지 미리보기
+  useEffect(() => {
+    if (imageFile) {
+      const url = URL.createObjectURL(imageFile);
+      setImagePreview(url);
+
+      // 미리보기가 있을 때만 클린업 함수로 메모리 해제
+      return () => {
+        URL.revokeObjectURL(url);
+      };
+    }
+  }, [imageFile, initialImageUrl]);
+
+  return { imageFile, imagePreview, handleFileChange };
+}
+
+export default useImagePreview;
+
+/* 매개변수
+
+초기 이미지 URL. 기본값은 빈 문자열 ""
+
+반환값
+
+imageFile: 사용자가 업로드한 이미지 파일 객체
+예: { name: "profile.png", size: 34567, type: "image/png", ... }
+
+imagePreview: 업로드된 이미지의 미리 보기 URL
+예: "blob:http://localhost:3000/..."
+초기값은 인자로 받은 initialImageUrl을 반환
+
+handleFileChange: 파일 선택 이벤트 핸들러
+<input type="file" /> 요소의 onChange 이벤트에 사용 */

--- a/src/pages/profile-setting/index.tsx
+++ b/src/pages/profile-setting/index.tsx
@@ -22,7 +22,9 @@ function ProfileSetting() {
     },
   });
 
-  const onSubmit = (data: z.infer<typeof profileSettingSchema>) => console.log(data);
+  const onSubmit = (data: z.infer<typeof profileSettingSchema>) => {
+    console.log(data);
+  };
 
   const handleSaveClick = useCallback(() => {
     //즉시실행함수를 이용해 검증을 마치고 바로 제출
@@ -31,11 +33,11 @@ function ProfileSetting() {
 
   return (
     <PageLayout>
-      <div className="web:w-[661px] mobile:w-screen flex flex-col mobile:px-[16px]">
+      <div className="w-screen web:w-[661px] flex flex-col px-4 web:px-0">
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col w-full">
             <ProfileSettingAvatar imageUrl="https://github.com/shadcn.png" />
-            <p className="mb-4 font-bold text-text-lg web:text-text-2xl">프로필 편집</p>
+            <p className="mt-8 mb-4 font-bold text-text-lg web:text-text-2xl">프로필 편집</p>
             <ProfileSettingForm />
             <AccountSettings />
             <section className="flex justify-between mt-[50px]">

--- a/src/pages/profile-setting/index.tsx
+++ b/src/pages/profile-setting/index.tsx
@@ -1,76 +1,51 @@
-import PenIcon from '@/components/Icons/PenIcon';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
-import DeleteAccountConfirmButton from '@/features/profile-setting/DeleteAccountConfirmButton';
+import { Form } from '@/components/ui/form';
+import AccountSettings from '@/features/profile-setting/AccountSettings';
+import ProfileSettingAvatar from '@/features/profile-setting/ProfileSettingAvatar';
+import ProfileSettingForm from '@/features/profile-setting/ProfileSettingForm';
 import SaveProfileButton from '@/features/profile-setting/SaveProfileButton';
 import PageLayout from '@/layouts/PageLayout';
+import { profileSettingSchema } from '@/services/schemas/profileSchema';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useCallback } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
 
 function ProfileSetting() {
+  const form = useForm({
+    resolver: zodResolver(profileSettingSchema),
+    defaultValues: {
+      name: '',
+      imageUrl: 'https://github.com/shadcn.png' /* 추후에 유저의 데이터로 변경 */,
+      description: '',
+      instagramId: '',
+    },
+  });
+
+  const onSubmit = (data: z.infer<typeof profileSettingSchema>) => console.log(data);
+
+  const handleSaveClick = useCallback(() => {
+    //즉시실행함수를 이용해 검증을 마치고 바로 제출
+    form.handleSubmit(onSubmit)();
+  }, [form, onSubmit]);
+
   return (
-    <PageLayout className="">
+    <PageLayout>
       <div className="web:w-[661px] mobile:w-screen flex flex-col mobile:px-[16px]">
-        <article className=" flex justify-center mb-[32px]">
-          <div className="relative">
-            <Avatar className="w-[100px] h-[100px]">
-              <AvatarImage src="https://github.com/shadcn.png" alt="@shadcn" />
-              <AvatarFallback>CN</AvatarFallback>
-            </Avatar>
-            <div className="flex justify-center bg-white items-center w-[26px] h-[26px] z-10 rounded-[60px] border border-[#E5E6E8] absolute right-0 bottom-0">
-              <PenIcon className="w-4 h-4 stroke-black" />
-            </div>
-          </div>
-        </article>
-        <section className="mb-[40px]">
-          <p className="mb-4 form-section-heading">프로필 편집</p>
-          <form className="flex flex-col gap-[20px]">
-            <section className="flex flex-col form-field-border-bttom">
-              <div className="flex items-center justify-between">
-                <label htmlFor="" className="py-[5px] form-label">
-                  닉네임
-                </label>
-                <span className="form-count">14/30</span>
-              </div>
-              <input placeholder="Spoteditor-123" className="py-1" />
-            </section>
-            <section className="flex flex-col form-field-border-bttom">
-              <div className="flex items-center justify-between">
-                <label htmlFor="" className="py-[5px] form-label">
-                  프로필 설명
-                </label>
-                <span className="form-count">14/30</span>
-              </div>
-              <textarea
-                placeholder="소소한 하루, 특별한 순간들을 기록하는 공간 ☕️ 일상의 작은 행복부터 여행의 찰나까지 🏞"
-                className="py-1 break-words resize-none"
-              />
-            </section>
-            <section className="flex flex-col form-field-border-bttom">
-              <div className="flex items-center justify-between">
-                <label htmlFor="" className="py-[5px] form-label">
-                  인스타그램
-                </label>
-              </div>
-              <input placeholder="@" className="py-1" />
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col w-full">
+            <ProfileSettingAvatar imageUrl="https://github.com/shadcn.png" />
+            <p className="mb-4 font-bold text-text-lg web:text-text-2xl">프로필 편집</p>
+            <ProfileSettingForm />
+            <AccountSettings />
+            <section className="flex justify-between mt-[50px]">
+              <Button variant="outline" className="rounded-[6px] w-[120px] h-[42px]">
+                취소
+              </Button>
+              <SaveProfileButton onTrigger={handleSaveClick} />
             </section>
           </form>
-        </section>
-        <section>
-          <p className="mb-4 font-bold text-text-2xl">계정 설정</p>
-          <div className="flex items-center justify-between py-[5px]">
-            <p className="form-label">계정 삭제</p>
-            <DeleteAccountConfirmButton />
-          </div>
-          <p className="text-primarySlate font-12 leading-[18px] font-medium">
-            계정 삭제시 등록된 로그는 삭제되지 않습니다. <br /> 로그를 삭제하시려면 개별 삭제를
-            해주세요.
-          </p>
-        </section>
-        <section className="flex justify-between mt-[50px]">
-          <Button variant="outline" className="rounded-[6px] w-[120px] h-[42px]">
-            취소
-          </Button>
-          <SaveProfileButton />
-        </section>
+        </Form>
       </div>
     </PageLayout>
   );

--- a/src/services/schemas/profileSchema.ts
+++ b/src/services/schemas/profileSchema.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const profileSettingSchema = z.object({
+  name: z
+    .string()
+    .max(30, { message: '닉네임은 30글자를 넘을 수 없습니다.' })
+    .min(1, { message: '' }),
+  imageUrl: z
+    .string()
+    .url({ message: '올바른 이미지 URL을 입력해주세요.' })
+    .refine(
+      (val) => {
+        return /\.(jpeg|jpg|png|gif)$/i.test(val);
+      },
+      { message: '이미지는 JPEG, PNG, GIF만 업로드 가능합니다.' }
+    ),
+  description: z
+    .string()
+    .max(50, { message: '프로필 설명은 50글자를 넘을 수 없습니다.' })
+    .min(5, { message: '' }),
+  instagramId: z.string(),
+});


### PR DESCRIPTION
## 📌 작업 주제

- 프로필 설정 페이지 리팩토링 및 이미지 업로드 기능 추가

## 🛠 작업 내용

 - 프로필 세팅 페이지 진입 버튼을 프로필 모달창에서 프로필 페이지의 편집 버튼으로 변경
- 리액트 훅 폼 적용
- 프로필 세팅의 컴포넌트 분리
- 이미지 업로드 및 미리보기 훅 추가
- 저장 버튼 최적화: useCallback을 활용하여 handleSubmit을 최적화하고 불필요한 리렌더링 방지
- form.watch()를 사용하여 닉네임, 프로필 설명 입력값의 길이를 실시간으로 화면에 렌더링

## 📚 추가 내용 (선택)
### useImagePreview 훅
 - 사용자가 업로드한 이미지를 미리보기할 수 있도록 도와주는 커스텀 훅
 - 파일 선택 시 URL.createObjectURL을 활용하여 미리보기 URL을 생성하며, 컴포넌트가 언마운트되거나 파일이 변경될 경우 메모리를 해제

#### 사용 예시
```tsx
function ProfileSettingAvatar() {
  const { imageFile, imagePreview, handleFileChange } = useImagePreview('https://example.com/default-avatar.png');

  return (
    <div>
      <img src={imagePreview} alt="프로필 이미지 미리보기" className="w-24 h-24 rounded-full" />
      <input type="file" accept="image/*" onChange={handleFileChange} />
    </div>
  );
}
```
#### 매개변수
 - 초기 이미지 URL. 기본값은 빈 문자열

#### 반환값
 - imageFile
   - 사용자가 선택한 이미지 파일 객체
   - 예시: `{ name: "profile.png", size: 34567, type: "image/png", ... }`
 - imagePreview
   - 업로드된 이미지의 미리 보기용 URL
   - 예시: "blob:http://localhost:3000/..."
 - handleFileChange
   - `<input type="file">`의 onChange 핸들러