### PR TITLE
등록 페이지 추가 퍼블리싱 및 지도 기능 수정 

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,10 +6,6 @@
   <link rel="icon" type="image/svg+xml" href="/vite.svg" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Spoteditor</title>
-
-  <!-- 임시 -->
-  <script type="text/javascript"
-    src="//dapi.kakao.com/v2/maps/sdk.js?appkey=92cdf5fbfd37cdac14f64365de030955&libraries=services"></script>
 </head>
 
 <body>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[6px] text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[6px] text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:bg-primary-50 disabled:!text-primary-300 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 ',
   {
     variants: {
       variant: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -13,6 +13,7 @@ const buttonVariants = cva(
         outline: 'border border-primary-100 bg-white hover:bg-neutral-100 hover:text-neutral-900',
         ghost: 'bg-primary-50 hover:bg-primary-200 hover:text-primary-400',
         muted: 'bg-primary-50 !text-primary-300 hover:bg-primary-200 hover:text-primary-400',
+        transparent: 'bg-transparent',
       },
       fullRounded: {
         true: 'rounded-[60px]',

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -11,7 +11,7 @@ const buttonVariants = cva(
       variant: {
         default: 'bg-black !text-gray-50 hover:bg-black/90',
         outline: 'border border-primary-100 bg-white hover:bg-neutral-100 hover:text-neutral-900',
-        ghost: 'bg-primary-50',
+        ghost: 'bg-primary-50 hover:bg-primary-200 hover:text-primary-400',
         muted: 'bg-primary-50 !text-primary-300 hover:bg-primary-200 hover:text-primary-400',
       },
       fullRounded: {

--- a/src/features/registerpage/PlaceDetailFormItem.tsx
+++ b/src/features/registerpage/PlaceDetailFormItem.tsx
@@ -1,59 +1,64 @@
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
-import { Camera, CircleX, Clock, GripVertical, MapPin, Star } from 'lucide-react';
+import { KakaoPlace } from '@/pages/register/types/place.type';
+import { Camera, ChevronRight, Circle, CircleCheck, Clock, MapPin } from 'lucide-react';
+import { useState } from 'react';
 
-const PlaceDetailFormItem = () => {
+const PlaceDetailFormItem = ({ place, idx }: { place: KakaoPlace; idx: number }) => {
+  const [isChecked, setIsChecked] = useState(false);
+  const handleChecked = () => setIsChecked((prev) => !prev);
+
   return (
-    <div className="flex w-full">
-      <GripVertical className="stroke-primary-300 mr-1 cursor-pointer" />
-      <div className="grow">
-        {/* 장소 설명 */}
-
-        <div className="flex flex-col gap-2">
+    <div className="py-[5px]">
+      {/* 장소 설명 */}
+      <div className="flex flex-col gap-2">
+        <div className="text-text-lg font-bold">
           <div className="flex justify-between">
-            <div className="text-text-lg font-bold">
-              <p>01</p>
-              <p>서촌 베란다</p>
-            </div>
-            <CircleX className="fill-primary-100 stroke-white" />
+            <p>{String(idx).padStart(2, '0')}</p>
+            {isChecked ? (
+              <CircleCheck className="fill-black stroke-white" onClick={handleChecked} />
+            ) : (
+              <Circle className="stroke-neutral-200" onClick={handleChecked} />
+            )}
           </div>
-          <div className="flex flex-col  text-primary-400">
-            <div className="flex gap-2 items-center text-text-sm">
-              <Clock size={16} />
-              <p className="after:ml-1.5 after:content-['|'] after:text-primary-100">카페</p>
-              <p className="text-info-500">영업중</p>
-              <p>오후 8시에 영업종료</p>
-            </div>
-            <div className="flex gap-2 items-center text-text-sm">
-              <MapPin size={16} />
-              <p className="after:ml-1.5 after:content-['|'] after:text-primary-100">서울</p>
-              <p>위치 세부정보</p>
-            </div>
+          <p className="flex items-center">
+            {place.place_name} <ChevronRight />
+          </p>
+        </div>
+
+        <div className="flex flex-col text-primary-400">
+          <div className="flex gap-2 items-center text-text-sm">
+            <Clock size={16} />
+            <p className="after:ml-1.5 after:content-['|'] after:text-primary-100">
+              {place.category_group_name}
+            </p>
+            <p className="text-info-500">영업중</p>
+            <p>오후 8시에 영업종료</p>
+          </div>
+          <div className="flex gap-2 items-center text-text-sm">
+            <MapPin size={16} />
+            <p className="after:ml-1.5 after:content-['|'] after:text-primary-100">
+              {place.road_address_name.split(' ')[0]}
+            </p>
+            <p>{place.road_address_name}</p>
           </div>
         </div>
-        {/* 사진 첨부 */}
-        <Button
-          variant={'outline'}
-          className="border w-full border-dashed gap-[5px] text-primary-600 px-2.5 py-3 mt-[15px]"
-        >
-          <Camera />
-          <span className="text-text-sm font-bold">사진첨부 (최대 3장)</span>
-        </Button>
-        {/* 평점 */}
-        <div className="flex justify-center items-center gap-[5px] text-primary-400 px-4 py-3">
-          <span>평점</span>
-          <div className="flex">
-            {[...Array(5)].map((_, idx) => (
-              <Star key={idx} className="fill-primary-100 stroke-none" />
-            ))}
-          </div>
-        </div>
-        {/* 내용 */}
-        <Textarea
-          className="bg-primary-50 text-primary-300 text-text-sm placeholder:text-primary-300 border-none focus-visible:ring-0 focus-visible:ring-offset-0"
-          placeholder="내용을 입력해주세요. (최대 500자)"
-        />
       </div>
+
+      {/* 사진 첨부 */}
+      <Button
+        variant={'outline'}
+        className="border w-full border-dashed gap-[5px] text-primary-600 px-2.5 py-3 mt-[15px] mb-2.5"
+      >
+        <Camera />
+        <span className="text-text-sm font-bold">사진첨부 (최대 3장)</span>
+      </Button>
+
+      {/* 내용 */}
+      <Textarea
+        className="bg-primary-50 text-primary-300 text-text-sm placeholder:text-primary-300 border-none focus-visible:ring-0 focus-visible:ring-offset-0"
+        placeholder="내용을 입력해주세요. (최대 500자)"
+      />
     </div>
   );
 };

--- a/src/features/registerpage/PlaceListItem.tsx
+++ b/src/features/registerpage/PlaceListItem.tsx
@@ -1,13 +1,24 @@
 import { Button } from '@/components/ui/button';
+import { useRegisterStore } from '@/store/registerStore';
+import { useId } from 'react';
 
 const PlaceListItem = () => {
+  const addSearchPlace = useRegisterStore((state) => state.addSearchPlace);
+  const handleAddClick = (place) => addSearchPlace(place);
+  const id = useId();
+
   return (
     <div className="flex justify-between py-1 items-center">
       <div className="text-text-sm font-medium">
         <h5>장소명</h5>
         <p className="text-primary-300">관광명소 · 포항 · 안동</p>
       </div>
-      <Button variant={'ghost'} size={'s'} fullRounded>
+      <Button
+        variant={'ghost'}
+        size={'s'}
+        fullRounded
+        onClick={() => handleAddClick(`새로운 장소 ${id}`)}
+      >
         선택
       </Button>
     </div>

--- a/src/features/registerpage/PlaceListItem.tsx
+++ b/src/features/registerpage/PlaceListItem.tsx
@@ -7,7 +7,7 @@ const PlaceListItem = () => {
         <h5>장소명</h5>
         <p className="text-primary-300">관광명소 · 포항 · 안동</p>
       </div>
-      <Button variant={'ghost'} size={'m'} fullRounded>
+      <Button variant={'ghost'} size={'s'} fullRounded>
         선택
       </Button>
     </div>

--- a/src/features/registerpage/PlaceListItem.tsx
+++ b/src/features/registerpage/PlaceListItem.tsx
@@ -1,24 +1,20 @@
 import { Button } from '@/components/ui/button';
+import { KakaoPlace } from '@/pages/register/types/place.type';
 import { useRegisterStore } from '@/store/registerStore';
-import { useId } from 'react';
 
-const PlaceListItem = () => {
-  const addSearchPlace = useRegisterStore((state) => state.addSearchPlace);
-  const handleAddClick = (place) => addSearchPlace(place);
-  const id = useId();
+const PlaceListItem = ({ place }: { place: KakaoPlace }) => {
+  const addSelectedPlace = useRegisterStore((state) => state.addSelectedPlace);
+
+  const { place_name, category_group_name, address_name } = place;
+  const [city, district] = address_name.split(' ');
 
   return (
     <div className="flex justify-between py-1 items-center">
       <div className="text-text-sm font-medium">
-        <h5>장소명</h5>
-        <p className="text-primary-300">관광명소 · 포항 · 안동</p>
+        <h5>{place_name}</h5>
+        <p className="text-primary-300">{`${category_group_name} · ${city} · ${district}`}</p>
       </div>
-      <Button
-        variant={'ghost'}
-        size={'s'}
-        fullRounded
-        onClick={() => handleAddClick(`새로운 장소 ${id}`)}
-      >
+      <Button variant={'ghost'} size={'s'} fullRounded onClick={() => addSelectedPlace(place)}>
         선택
       </Button>
     </div>

--- a/src/features/registerpage/RegisterSearchBar.tsx
+++ b/src/features/registerpage/RegisterSearchBar.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { MAPS } from '@/constants/pathname';
 import { ArrowLeft, Search } from 'lucide-react';
-import { FormEvent, ForwardedRef, forwardRef } from 'react';
+import React, { FormEvent, ForwardedRef, forwardRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 const RegisterSearchBar = forwardRef(
@@ -10,22 +10,26 @@ const RegisterSearchBar = forwardRef(
     { onSubmit }: { onSubmit?: (e: FormEvent<HTMLFormElement>) => void },
     ref?: ForwardedRef<HTMLInputElement>
   ) => {
-    const navigate = useNavigate();
-    const handleGoBack = () => navigate(-1);
+    const navi = useNavigate();
+    const handleGoBack = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      navi(-1);
+    };
 
     return (
       <form
         className="border-b flex items-center mt-3 px-4"
         onSubmit={onSubmit}
-        onClick={() => navigate(MAPS)}
+        onClick={() => navi(MAPS)}
       >
-        <ArrowLeft size={24} onClick={handleGoBack} className="cursor-pointer" />
+        <ArrowLeft onClick={handleGoBack} className="cursor-pointer" />
         <Input
           ref={ref}
           placeholder="장소를 검색해보세요."
           className="placeholder:text-primary-300 text-text-lg font-medium"
         />
-        <Button type="submit">
+
+        <Button type="submit" className="px-0 [&_svg]:size-auto" variant={'transparent'}>
           <Search />
         </Button>
       </form>

--- a/src/features/registerpage/RegisterSearchBar.tsx
+++ b/src/features/registerpage/RegisterSearchBar.tsx
@@ -18,18 +18,26 @@ const RegisterSearchBar = forwardRef(
 
     return (
       <form
-        className="border-b flex items-center mt-3 px-4"
+        className="border-b flex items-center mt-3"
         onSubmit={onSubmit}
         onClick={() => navi(MAPS)}
       >
-        <ArrowLeft onClick={handleGoBack} className="cursor-pointer" />
+        <Button
+          type="submit"
+          className="px-4 [&_svg]:size-auto"
+          variant={'transparent'}
+          onClick={handleGoBack}
+        >
+          <ArrowLeft />
+        </Button>
+
         <Input
           ref={ref}
           placeholder="장소를 검색해보세요."
           className="placeholder:text-primary-300 text-text-lg font-medium"
         />
 
-        <Button type="submit" className="px-0 [&_svg]:size-auto" variant={'transparent'}>
+        <Button type="submit" className="px-4 [&_svg]:size-auto" variant={'transparent'}>
           <Search />
         </Button>
       </form>

--- a/src/features/registerpage/RegisterSearchBar.tsx
+++ b/src/features/registerpage/RegisterSearchBar.tsx
@@ -15,7 +15,7 @@ const RegisterSearchBar = forwardRef(
 
     return (
       <form
-        className="border-b flex items-center"
+        className="border-b flex items-center mt-3 px-4"
         onSubmit={onSubmit}
         onClick={() => navigate(MAPS)}
       >

--- a/src/features/registerpage/RegisterSearchBar.tsx
+++ b/src/features/registerpage/RegisterSearchBar.tsx
@@ -5,25 +5,27 @@ import { ArrowLeft, Search } from 'lucide-react';
 import React, { FormEvent, ForwardedRef, forwardRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+interface RegisterSearchBarProps {
+  to: string;
+  onSubmit?: (e: FormEvent<HTMLFormElement>) => void;
+}
+
 const RegisterSearchBar = forwardRef(
-  (
-    { onSubmit }: { onSubmit?: (e: FormEvent<HTMLFormElement>) => void },
-    ref?: ForwardedRef<HTMLInputElement>
-  ) => {
+  ({ to, onSubmit }: RegisterSearchBarProps, ref?: ForwardedRef<HTMLInputElement>) => {
     const navi = useNavigate();
     const handleGoBack = (e: React.MouseEvent) => {
       e.stopPropagation();
-      navi(-1);
+      navi(to);
     };
 
     return (
       <form
-        className="border-b flex items-center mt-3"
+        className="border-b flex items-center mt-3 w-full"
         onSubmit={onSubmit}
         onClick={() => navi(MAPS)}
       >
         <Button
-          type="submit"
+          type="button"
           className="px-4 [&_svg]:size-auto"
           variant={'transparent'}
           onClick={handleGoBack}

--- a/src/layouts/RegisterLayout.tsx
+++ b/src/layouts/RegisterLayout.tsx
@@ -3,7 +3,7 @@ import { Outlet } from 'react-router-dom';
 const RegisterLayout = () => {
   return (
     <div className="flex flex-col items-center h-screen mx-auto web:w-[724px]">
-      <div className="w-full h-full grow px-4 py-3">
+      <div className="w-full h-full grow">
         <Outlet />
       </div>
     </div>

--- a/src/pages/register/DetailsPage.tsx
+++ b/src/pages/register/DetailsPage.tsx
@@ -1,18 +1,31 @@
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
+import { REGISTER_SEARCH } from '@/constants/pathname';
 import PlaceDetailFormItem from '@/features/registerpage/PlaceDetailFormItem';
-import { ArrowLeft, Plus } from 'lucide-react';
+import { useRegisterStore } from '@/store/registerStore';
+import { ArrowLeft, Camera } from 'lucide-react';
 import { Link, useNavigate } from 'react-router-dom';
 
 // 스크롤 수정 필요
 const DetailsPage = () => {
   const navi = useNavigate();
+  const selectedPlaces = useRegisterStore((state) => state.selectedPlaces);
+
   return (
     <div className="h-full flex flex-col">
-      <header className="flex items-center gap-2.5 pb-3">
-        <ArrowLeft size={24} onClick={() => navi(-1)} className="cursor-pointer" />
-        <h3 className="text-text-2xl font-bold">서울 · 종로구</h3>
+      <header className="flex items-center py-3 justify-between">
+        <div className="flex gap-2.5">
+          <ArrowLeft size={24} onClick={() => navi(-1)} className="cursor-pointer" />
+          <h3 className="text-text-2xl font-bold">서울 · 종로구</h3>
+        </div>
+        <Button
+          variant={'transparent'}
+          className="text-primary-300 !text-text-md"
+          onClick={() => navi(REGISTER_SEARCH)}
+        >
+          장소 추가
+        </Button>
       </header>
 
       <main className="flex flex-col items-center grow gap-3 min-h-0 overflow-y-auto scrollbar-hide">
@@ -22,29 +35,51 @@ const DetailsPage = () => {
           className="border-b px-0 placeholder:text-primary-300 placeholder:after:content-['*'] placeholder:after:text-red-500"
         />
 
+        <Button
+          variant={'outline'}
+          className="border w-full border-dashed gap-[5px] text-primary-600 px-2.5 py-3"
+        >
+          <Camera />
+          <span className="text-text-sm font-bold">
+            커버이미지<span className="text-error-600 m-1">*</span>
+          </span>
+        </Button>
+
         <Textarea
           className="bg-primary-50 text-primary-300 text-text-sm placeholder:text-primary-300 border-none focus-visible:ring-0 focus-visible:ring-offset-0"
           placeholder="내용을 입력해주세요. (최대 500자)"
         />
 
-        {/* 버튼 클릭하면  PlaceDetailFormItem 추가하기*/}
-        <PlaceDetailFormItem />
-        <PlaceDetailFormItem />
-        <PlaceDetailFormItem />
-
-        <Button
-          className="w-full text-primary-600 font-bold text-text-sm mb-10"
-          variant={'outline'}
-        >
-          <Plus />
-          장소 추가
-        </Button>
+        <div className="flex flex-col w-full">
+          {selectedPlaces.map((place, idx) => (
+            <PlaceDetailFormItem place={place} key={place.id} idx={idx + 1} />
+          ))}
+        </div>
       </main>
 
       {/* 버튼 */}
-      <Button className="w-full mb-3" asChild size={'xl'}>
-        <Link to={'#'}>완료</Link>
-      </Button>
+      {/* {isChecked ? (
+        <div className="bg-black grid grid-cols-3 pt-2 pb-3">
+          <Button>
+            <ArrowUp />
+            위로
+          </Button>
+          <Button>
+            <ArrowDown />
+            아래로
+          </Button>
+          <Button>
+            <Trash />
+            삭제하기
+          </Button>
+        </div>
+      ) : ( */}
+      <div className="pt-2 pb-3 px-4">
+        <Button className="w-full" asChild size={'xl'}>
+          <Link to={'#'}>완료</Link>
+        </Button>
+      </div>
+      {/* )} */}
     </div>
   );
 };

--- a/src/pages/register/MapPage.tsx
+++ b/src/pages/register/MapPage.tsx
@@ -46,7 +46,7 @@ const MapPage = () => {
 
       const options = {
         center: new window.kakao.maps.LatLng(lat, lon), // 직접 lat, lon 사용
-        level: 2,
+        level: 3,
       };
 
       mapRef.current = new window.kakao.maps.Map(mapContainerRef.current, options);
@@ -81,8 +81,10 @@ const MapPage = () => {
       displayPlaces(result);
     } else if (status === window.kakao.maps.services.Status.ZERO_RESULT) {
       alert('검색 결과가 없습니다.');
+      setPlaces([]);
     } else if (status === window.kakao.maps.services.Status.ERROR) {
       alert('검색 중 오류가 발생했습니다.');
+      setPlaces([]);
     }
   };
 

--- a/src/pages/register/NewPlacePage.tsx
+++ b/src/pages/register/NewPlacePage.tsx
@@ -1,0 +1,56 @@
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { ArrowLeft } from 'lucide-react';
+import { Link, useNavigate } from 'react-router-dom';
+
+const NewPlacePage = () => {
+  const navi = useNavigate();
+  return (
+    <div className="flex flex-col h-full px-4">
+      <header className="mt-3 flex items-center gap-2 border-b pb-2 border-primary-50">
+        <ArrowLeft size={24} onClick={() => navi(-1)} className="cursor-pointer" />
+        <h3 className="text-text-2xl font-bold">새로운 장소 추가하기</h3>
+      </header>
+
+      <main className="grow">
+        <div className="py-5">
+          <div className="flex font-text-sm font-bold gap-1">
+            <h4>장소명</h4>
+            <span className="text-error-600">*</span>
+          </div>
+          <Input
+            placeholder="공간명을 입력해주세요"
+            className="border-b border-primary-100 px-0 text-primary-500 font-medium placeholder:text-primary-200"
+          />
+        </div>
+        <div className="py-5">
+          <div className="flex font-text-sm font-bold gap-1">
+            <h4>위치</h4>
+            <span className="text-error-600">*</span>
+          </div>
+          <Input
+            placeholder="주소 검색"
+            className="border-b border-primary-100 px-0 text-primary-500 font-medium placeholder:text-primary-200"
+          />
+        </div>
+        <div className="py-5">
+          <div className="flex font-text-sm font-bold gap-1">
+            <h4>공간 유형</h4>
+            <span className="text-error-600">*</span>
+          </div>
+          <Input
+            placeholder="공간 유형을 입력해주세요"
+            className="border-b border-primary-100 px-0 text-primary-500 font-medium placeholder:text-primary-200"
+          />
+        </div>
+      </main>
+
+      {/* 버튼 */}
+      <Button className="w-full mb-3" asChild size={'xl'}>
+        <Link to={'#'}>완료</Link>
+      </Button>
+    </div>
+  );
+};
+
+export default NewPlacePage;

--- a/src/pages/register/SearchPage.tsx
+++ b/src/pages/register/SearchPage.tsx
@@ -5,21 +5,23 @@ import RegisterSearchBar from '@/features/registerpage/RegisterSearchBar';
 import { useRegisterStore } from '@/store/registerStore';
 import { CircleX } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import { KakaoPlace } from './types/place.type';
 
 const SearchPage = () => {
-  const searchPlaces = useRegisterStore((state) => state.searchPlaces);
-  const removeSearchPlace = useRegisterStore((state) => state.removeSearchPlace);
+  const selectedPlaces = useRegisterStore((state) => state.selectedPlaces);
+  const recentSearchPlaces = useRegisterStore((state) => state.recentSearchPlaces);
+  const removeSelectedPlace = useRegisterStore((state) => state.removeSelectedPlace);
 
-  const handleRemoveClick = (place) => removeSearchPlace(place);
+  const handleRemoveClick = (place: KakaoPlace) => removeSelectedPlace(place);
   return (
     <div className="h-full flex flex-col">
       <RegisterSearchBar />
 
-      {searchPlaces.length > 0 && (
+      {selectedPlaces.length > 0 && (
         <div className="px-4 py-[14px] bg-primary-50 text-text-sm font-medium flex gap-3">
-          {searchPlaces.map((place, idx) => (
+          {selectedPlaces.map((place, idx) => (
             <span className="flex items-center gap-[3px] cursor-pointer" key={idx}>
-              {place}
+              {place.place_name}
               <CircleX className="p-1" onClick={() => handleRemoveClick(place)} />
             </span>
           ))}
@@ -30,15 +32,17 @@ const SearchPage = () => {
         {/* 최근 검색 */}
         <div className="w-full">
           <h3 className="text-text-2xl font-bold pt-5 pb-2.5">최근 검색한 장소</h3>
-          {[...Array(5)].map((_, idx) => (
-            <PlaceListItem key={idx} />
+          {recentSearchPlaces?.map((place, idx) => (
+            <PlaceListItem key={idx} place={place} />
           ))}
         </div>
 
         {/* 5개부터 활성화 */}
-        <Button className="w-full" variant={'ghost'}>
-          전체보기
-        </Button>
+        {recentSearchPlaces.length > 4 && (
+          <Button className="w-full" variant={'ghost'}>
+            전체보기
+          </Button>
+        )}
       </main>
 
       {/* 버튼 */}

--- a/src/pages/register/SearchPage.tsx
+++ b/src/pages/register/SearchPage.tsx
@@ -1,12 +1,14 @@
 import { Button } from '@/components/ui/button';
-import { REGISTER_SELECT } from '@/constants/pathname';
+import { REGISTER_DETAILS, REGISTER_SELECT } from '@/constants/pathname';
 import PlaceListItem from '@/features/registerpage/PlaceListItem';
 import RegisterSearchBar from '@/features/registerpage/RegisterSearchBar';
 import { useRegisterStore } from '@/store/registerStore';
 import { CircleX } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import { KakaoPlace } from './types/place.type';
 
 const SearchPage = () => {
+  const navi = useNavigate();
   const selectedPlaces = useRegisterStore((state) => state.selectedPlaces);
   const recentSearchPlaces = useRegisterStore((state) => state.recentSearchPlaces);
   const removeSelectedPlace = useRegisterStore((state) => state.removeSelectedPlace);
@@ -46,7 +48,12 @@ const SearchPage = () => {
 
       {/* 버튼 */}
       <div className="pt-2 pb-6 px-4">
-        <Button className="w-full" size={'xl'} disabled={!selectedPlaces.length}>
+        <Button
+          className="w-full"
+          size={'xl'}
+          disabled={!selectedPlaces.length}
+          onClick={() => navi(REGISTER_DETAILS)}
+        >
           다음
         </Button>
       </div>

--- a/src/pages/register/SearchPage.tsx
+++ b/src/pages/register/SearchPage.tsx
@@ -1,10 +1,9 @@
 import { Button } from '@/components/ui/button';
-import { REGISTER_DETAILS } from '@/constants/pathname';
+import { REGISTER_SELECT } from '@/constants/pathname';
 import PlaceListItem from '@/features/registerpage/PlaceListItem';
 import RegisterSearchBar from '@/features/registerpage/RegisterSearchBar';
 import { useRegisterStore } from '@/store/registerStore';
 import { CircleX } from 'lucide-react';
-import { Link } from 'react-router-dom';
 import { KakaoPlace } from './types/place.type';
 
 const SearchPage = () => {
@@ -15,7 +14,7 @@ const SearchPage = () => {
   const handleRemoveClick = (place: KakaoPlace) => removeSelectedPlace(place);
   return (
     <div className="h-full flex flex-col">
-      <RegisterSearchBar />
+      <RegisterSearchBar to={REGISTER_SELECT} />
 
       {selectedPlaces.length > 0 && (
         <div className="px-4 py-[14px] bg-primary-50 text-text-sm font-medium flex gap-3">
@@ -46,9 +45,11 @@ const SearchPage = () => {
       </main>
 
       {/* 버튼 */}
-      <Button className="w-full mb-3" asChild size={'xl'}>
-        <Link to={REGISTER_DETAILS}>완료</Link>
-      </Button>
+      <div className="pt-2 pb-6 px-4">
+        <Button className="w-full" size={'xl'} disabled={!selectedPlaces.length}>
+          다음
+        </Button>
+      </div>
     </div>
   );
 };

--- a/src/pages/register/SearchPage.tsx
+++ b/src/pages/register/SearchPage.tsx
@@ -2,6 +2,7 @@ import { Button } from '@/components/ui/button';
 import { REGISTER_DETAILS } from '@/constants/pathname';
 import PlaceListItem from '@/features/registerpage/PlaceListItem';
 import RegisterSearchBar from '@/features/registerpage/RegisterSearchBar';
+import { CircleX } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
 const SearchPage = () => {
@@ -9,26 +10,34 @@ const SearchPage = () => {
     <div className="h-full flex flex-col">
       <RegisterSearchBar />
 
-      <main className="flex flex-col items-center grow ">
+      <div className="px-4 py-[14px] bg-primary-50 text-text-sm font-medium flex gap-3">
+        <span className="flex items-center gap-[3px] cursor-pointer">
+          장소명
+          <CircleX className="p-1" />
+        </span>
+        <span className="flex items-center gap-[3px] cursor-pointer">
+          장소명
+          <CircleX className="p-1" />
+        </span>
+        <span className="flex items-center gap-[3px] cursor-pointer">
+          장소명
+          <CircleX className="p-1" />
+        </span>
+      </div>
+
+      <main className="flex flex-col items-center grow gap-[3px] px-4">
         {/* 최근 검색 */}
         <div className="w-full">
           <h3 className="text-text-2xl font-bold pt-5 pb-2.5">최근 검색한 장소</h3>
-          {[...Array(2)].map((_, idx) => (
-            <PlaceListItem key={idx} />
-          ))}
-        </div>
-
-        {/* 최근 저장 */}
-        <div className="w-full">
-          <h3 className="text-text-2xl font-bold pt-5 pb-2.5">저장된 장소</h3>
           {[...Array(5)].map((_, idx) => (
             <PlaceListItem key={idx} />
           ))}
-
-          <Button className="w-full" variant={'ghost'}>
-            전체보기
-          </Button>
         </div>
+
+        {/* 5개부터 활성화 */}
+        <Button className="w-full" variant={'ghost'}>
+          전체보기
+        </Button>
       </main>
 
       {/* 버튼 */}

--- a/src/pages/register/SearchPage.tsx
+++ b/src/pages/register/SearchPage.tsx
@@ -2,28 +2,29 @@ import { Button } from '@/components/ui/button';
 import { REGISTER_DETAILS } from '@/constants/pathname';
 import PlaceListItem from '@/features/registerpage/PlaceListItem';
 import RegisterSearchBar from '@/features/registerpage/RegisterSearchBar';
+import { useRegisterStore } from '@/store/registerStore';
 import { CircleX } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
 const SearchPage = () => {
+  const searchPlaces = useRegisterStore((state) => state.searchPlaces);
+  const removeSearchPlace = useRegisterStore((state) => state.removeSearchPlace);
+
+  const handleRemoveClick = (place) => removeSearchPlace(place);
   return (
     <div className="h-full flex flex-col">
       <RegisterSearchBar />
 
-      <div className="px-4 py-[14px] bg-primary-50 text-text-sm font-medium flex gap-3">
-        <span className="flex items-center gap-[3px] cursor-pointer">
-          장소명
-          <CircleX className="p-1" />
-        </span>
-        <span className="flex items-center gap-[3px] cursor-pointer">
-          장소명
-          <CircleX className="p-1" />
-        </span>
-        <span className="flex items-center gap-[3px] cursor-pointer">
-          장소명
-          <CircleX className="p-1" />
-        </span>
-      </div>
+      {searchPlaces.length > 0 && (
+        <div className="px-4 py-[14px] bg-primary-50 text-text-sm font-medium flex gap-3">
+          {searchPlaces.map((place, idx) => (
+            <span className="flex items-center gap-[3px] cursor-pointer" key={idx}>
+              {place}
+              <CircleX className="p-1" onClick={() => handleRemoveClick(place)} />
+            </span>
+          ))}
+        </div>
+      )}
 
       <main className="flex flex-col items-center grow gap-[3px] px-4">
         {/* 최근 검색 */}

--- a/src/pages/register/SelectPage.tsx
+++ b/src/pages/register/SelectPage.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@/components/ui/button';
 import { REGISTER_SEARCH } from '@/constants/pathname';
 import { ArrowLeft } from 'lucide-react';
+import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
 const WHO = ['혼자', '친구랑', '연인과', '가족과', '동료와', '반려동물과'];
@@ -25,15 +26,30 @@ const WHERE = [
 
 const SelectPage = () => {
   const navi = useNavigate();
+  const [selectedWithWho, setSelectedWithWho] = useState<string[]>([]);
+  const [selectedFeeling, setSelectedFeeling] = useState<string[]>([]);
+
+  const handleOptionButtonClick = (type: 'who' | 'feeling', value: string) => {
+    if (type === 'who') {
+      setSelectedWithWho((prev) =>
+        prev.includes(value) ? prev.filter((item) => item !== value) : [...prev, value]
+      );
+    } else if (type === 'feeling') {
+      setSelectedFeeling((prev) =>
+        prev.includes(value) ? prev.filter((item) => item !== value) : [...prev, value]
+      );
+    }
+  };
+
   return (
-    <div className="h-full flex flex-col">
-      <header>
+    <div className="h-full flex flex-col px-4">
+      <header className="mt-3">
         <ArrowLeft size={24} onClick={() => navi(-1)} className="cursor-pointer" />
       </header>
 
       <main className="flex flex-col items-center justify-center grow ">
         {/* 제목 */}
-        <div className="flex flex-col items-center font-bold py-5 gap-[7px]">
+        <div className="flex flex-col items-center font-bold mt-5 mb-[25px] gap-[7px]">
           <h3 className="text-md">어떤 하루인가요?</h3>
           <p className="text-text-sm text-primary-300">여러개를 선택할 수 있어요.</p>
         </div>
@@ -44,7 +60,13 @@ const SelectPage = () => {
             <h5 className="text-text-xs font-bold py-2.5">누구와</h5>
             <div className="flex gap-2 flex-wrap">
               {WHO.map((who, idx) => (
-                <Button key={idx} variant={'muted'} size={'m'} className="font-bold">
+                <Button
+                  key={idx}
+                  variant={selectedWithWho.includes(who) ? 'default' : 'muted'}
+                  size={'m'}
+                  className="font-bold"
+                  onClick={() => handleOptionButtonClick('who', who)}
+                >
                   {who}
                 </Button>
               ))}
@@ -56,7 +78,13 @@ const SelectPage = () => {
             <h5 className="text-text-xs font-bold py-2.5">어떤 느낌으로</h5>
             <div className="flex gap-2 flex-wrap">
               {WHERE.map((who, idx) => (
-                <Button key={idx} variant={'muted'} size={'m'} className="font-bold">
+                <Button
+                  key={idx}
+                  variant={selectedFeeling.includes(who) ? 'default' : 'muted'}
+                  size={'m'}
+                  className="font-bold"
+                  onClick={() => handleOptionButtonClick('feeling', who)}
+                >
                   {who}
                 </Button>
               ))}
@@ -66,12 +94,12 @@ const SelectPage = () => {
       </main>
 
       {/* 버튼 */}
-      <div className="w-full flex flex-col items-center gap-[15px]">
+      <div className="w-full flex flex-col items-center gap-[15px] mb-6">
         <Button className="w-full" asChild size={'xl'}>
           <Link to={REGISTER_SEARCH}>다음</Link>
         </Button>
 
-        <p className="underline text-primary-300 text-text-sm">다음에 하기</p>
+        <p className="underline text-primary-300 text-text-sm font-medium">다음에 하기</p>
       </div>
     </div>
   );

--- a/src/pages/register/SelectPage.tsx
+++ b/src/pages/register/SelectPage.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@/components/ui/button';
 import { REGISTER_SEARCH } from '@/constants/pathname';
+import { useRegisterStore } from '@/store/registerStore';
 import { ArrowLeft } from 'lucide-react';
-import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
 const WHO = ['혼자', '친구랑', '연인과', '가족과', '동료와', '반려동물과'];
@@ -26,25 +26,19 @@ const WHERE = [
 
 const SelectPage = () => {
   const navi = useNavigate();
-  const [selectedWithWho, setSelectedWithWho] = useState<string[]>([]);
-  const [selectedFeeling, setSelectedFeeling] = useState<string[]>([]);
+  const companions = useRegisterStore((state) => state.experience.selectedCompanions);
+  const feelings = useRegisterStore((state) => state.experience.selectedFeelings);
 
-  const handleOptionButtonClick = (type: 'who' | 'feeling', value: string) => {
-    if (type === 'who') {
-      setSelectedWithWho((prev) =>
-        prev.includes(value) ? prev.filter((item) => item !== value) : [...prev, value]
-      );
-    } else if (type === 'feeling') {
-      setSelectedFeeling((prev) =>
-        prev.includes(value) ? prev.filter((item) => item !== value) : [...prev, value]
-      );
-    }
-  };
+  const setCompanions = useRegisterStore((state) => state.setCompanions);
+  const setFeelings = useRegisterStore((state) => state.setFeelings);
 
   return (
     <div className="h-full flex flex-col px-4">
       <header className="mt-3">
-        <ArrowLeft size={24} onClick={() => navi(-1)} className="cursor-pointer" />
+        {/* 나중에 경로 수정 */}
+        <Link to={'/profile/1'}>
+          <ArrowLeft size={24} className="cursor-pointer" />
+        </Link>
       </header>
 
       <main className="flex flex-col items-center justify-center grow ">
@@ -62,10 +56,10 @@ const SelectPage = () => {
               {WHO.map((who, idx) => (
                 <Button
                   key={idx}
-                  variant={selectedWithWho.includes(who) ? 'default' : 'muted'}
+                  variant={companions.includes(who) ? 'default' : 'muted'}
                   size={'m'}
                   className="font-bold"
-                  onClick={() => handleOptionButtonClick('who', who)}
+                  onClick={() => setCompanions(who)}
                 >
                   {who}
                 </Button>
@@ -80,10 +74,10 @@ const SelectPage = () => {
               {WHERE.map((who, idx) => (
                 <Button
                   key={idx}
-                  variant={selectedFeeling.includes(who) ? 'default' : 'muted'}
+                  variant={feelings.includes(who) ? 'default' : 'muted'}
                   size={'m'}
                   className="font-bold"
-                  onClick={() => handleOptionButtonClick('feeling', who)}
+                  onClick={() => setFeelings(who)}
                 >
                   {who}
                 </Button>
@@ -95,11 +89,18 @@ const SelectPage = () => {
 
       {/* 버튼 */}
       <div className="w-full flex flex-col items-center gap-[15px] mb-6">
-        <Button className="w-full" asChild size={'xl'}>
-          <Link to={REGISTER_SEARCH}>다음</Link>
+        <Button
+          className="w-full"
+          size={'xl'}
+          disabled={!companions.length || !feelings.length}
+          onClick={() => navi(REGISTER_SEARCH)}
+        >
+          다음
         </Button>
 
-        <p className="underline text-primary-300 text-text-sm font-medium">다음에 하기</p>
+        <p className="underline text-primary-300 text-text-sm font-medium">
+          <Link to={REGISTER_SEARCH}>다음에 하기</Link>
+        </p>
       </div>
     </div>
   );

--- a/src/pages/register/index.tsx
+++ b/src/pages/register/index.tsx
@@ -1,4 +1,5 @@
 export { default as RegisterDetail } from './DetailsPage';
 export { default as MapPage } from './MapPage';
+export { default as NewPlacePage } from './NewPlacePage';
 export { default as SearchPage } from './SearchPage';
 export { default as SelectPage } from './SelectPage';

--- a/src/pages/register/types/Place.type.ts
+++ b/src/pages/register/types/Place.type.ts
@@ -1,0 +1,14 @@
+export type KakaoPlace = {
+  address_name: string; // 지번 주소
+  category_group_code: string; // 카테고리 코드 (ex. CE7: 카페)
+  category_group_name: string; // 카테고리 그룹명 (ex. 카페)
+  category_name: string; // 상세 카테고리 (ex. 음식점 > 카페)
+  distance: string; // 기준 좌표와의 거리 (미터 단위)
+  id: string; // 장소 ID
+  phone: string; // 전화번호 (없으면 빈 문자열)
+  place_name: string; // 장소명
+  place_url: string; // 카카오맵 URL
+  road_address_name: string; // 도로명 주소
+  x: string; // 경도 (longitude)
+  y: string; // 위도 (latitude)
+};

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -9,7 +9,7 @@ import ProfileSetting from '@/pages/profile-setting';
 import MyLogs from '@/pages/profile/my-logs';
 import SavedLogs from '@/pages/profile/saved-logs';
 import SavedSpaces from '@/pages/profile/saved-spaces';
-import { MapPage, SearchPage, SelectPage } from '@/pages/register';
+import { MapPage, NewPlacePage, SearchPage, SelectPage } from '@/pages/register';
 import DetailsPage from '@/pages/register/DetailsPage';
 import Search from '@/pages/search';
 import { createBrowserRouter } from 'react-router-dom';
@@ -60,6 +60,7 @@ const router = createBrowserRouter([
       { path: '/register/search', element: <SearchPage /> },
       { path: '/register/details', element: <DetailsPage /> },
       { path: '/register/maps', element: <MapPage /> },
+      { path: '/register/newPlace', element: <NewPlacePage /> },
     ],
   },
 ]);

--- a/src/store/registerStore.ts
+++ b/src/store/registerStore.ts
@@ -1,24 +1,32 @@
+import { KakaoPlace } from '@/pages/register/types/place.type';
 import { create } from 'zustand';
 
 type RegisterStoreState = {
-  searchPlaces: string[];
+  selectedPlaces: KakaoPlace[]; // 선택한 장소
+  recentSearchPlaces: KakaoPlace[]; // 최근 검색 장소
 };
 
 type RegisterStoreActions = {
-  addSearchPlace: (place) => void;
-  removeSearchPlace: (place) => void;
+  addSelectedPlace: (place: KakaoPlace) => void;
+  removeSelectedPlace: (place: KakaoPlace) => void;
 };
 
 type RegisterStore = RegisterStoreState & RegisterStoreActions;
 
 export const useRegisterStore = create<RegisterStore>()((set) => ({
-  searchPlaces: [],
-  addSearchPlace: (place) =>
+  selectedPlaces: [],
+  recentSearchPlaces: [],
+  addSelectedPlace: (place) =>
     set((state) => ({
-      searchPlaces: [...state.searchPlaces, place],
+      selectedPlaces: state.selectedPlaces.some((item) => item.id === place.id)
+        ? state.selectedPlaces
+        : [...state.selectedPlaces, place],
+      recentSearchPlaces: state.recentSearchPlaces.some((item) => item.id === place.id)
+        ? state.recentSearchPlaces
+        : [...state.recentSearchPlaces, place],
     })),
-  removeSearchPlace: (place) =>
+  removeSelectedPlace: (place) =>
     set((state) => ({
-      searchPlaces: state.searchPlaces.filter((item) => item !== place),
+      selectedPlaces: state.selectedPlaces.filter((item) => item !== place),
     })),
 }));

--- a/src/store/registerStore.ts
+++ b/src/store/registerStore.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand';
+
+type RegisterStoreState = {
+  searchPlaces: string[];
+};
+
+type RegisterStoreActions = {
+  addSearchPlace: (place) => void;
+  removeSearchPlace: (place) => void;
+};
+
+type RegisterStore = RegisterStoreState & RegisterStoreActions;
+
+export const useRegisterStore = create<RegisterStore>()((set) => ({
+  searchPlaces: [],
+  addSearchPlace: (place) =>
+    set((state) => ({
+      searchPlaces: [...state.searchPlaces, place],
+    })),
+  removeSearchPlace: (place) =>
+    set((state) => ({
+      searchPlaces: state.searchPlaces.filter((item) => item !== place),
+    })),
+}));

--- a/src/store/registerStore.ts
+++ b/src/store/registerStore.ts
@@ -2,6 +2,11 @@ import { KakaoPlace } from '@/pages/register/types/place.type';
 import { create } from 'zustand';
 
 type RegisterStoreState = {
+  experience: {
+    selectedCompanions: string[];
+    selectedFeelings: string[];
+  };
+
   selectedPlaces: KakaoPlace[]; // 선택한 장소
   recentSearchPlaces: KakaoPlace[]; // 최근 검색 장소
 };
@@ -9,13 +14,42 @@ type RegisterStoreState = {
 type RegisterStoreActions = {
   addSelectedPlace: (place: KakaoPlace) => void;
   removeSelectedPlace: (place: KakaoPlace) => void;
+  setCompanions: (whom: string) => void;
+  setFeelings: (feeling: string) => void;
 };
 
 type RegisterStore = RegisterStoreState & RegisterStoreActions;
 
 export const useRegisterStore = create<RegisterStore>()((set) => ({
+  // States
+  experience: {
+    selectedCompanions: [],
+    selectedFeelings: [],
+  },
   selectedPlaces: [],
   recentSearchPlaces: [],
+
+  // Actions
+  setCompanions: (whom) =>
+    set((state) => ({
+      experience: {
+        ...state.experience,
+        selectedCompanions: state.experience.selectedCompanions.includes(whom)
+          ? state.experience.selectedCompanions.filter((item) => item !== whom)
+          : [...state.experience.selectedCompanions, whom],
+      },
+    })),
+
+  setFeelings: (feeling) =>
+    set((state) => ({
+      experience: {
+        ...state.experience,
+        selectedFeelings: state.experience.selectedFeelings.includes(feeling)
+          ? state.experience.selectedFeelings.filter((item) => item !== feeling)
+          : [...state.experience.selectedFeelings, feeling],
+      },
+    })),
+
   addSelectedPlace: (place) =>
     set((state) => ({
       selectedPlaces: state.selectedPlaces.some((item) => item.id === place.id)
@@ -27,6 +61,6 @@ export const useRegisterStore = create<RegisterStore>()((set) => ({
     })),
   removeSelectedPlace: (place) =>
     set((state) => ({
-      selectedPlaces: state.selectedPlaces.filter((item) => item !== place),
+      selectedPlaces: state.selectedPlaces.filter((item) => item.id !== place.id),
     })),
 }));


### PR DESCRIPTION
## 📌 작업 주제

- 등록 페이지 추가 퍼블리싱 및 지도 기능 수정

## 🛠 작업 내용

- **RegisterLayout 수정**  
  - 셀렉트 페이지에서 다중 선택 기능을 구현하여 사용자가 여러 장소를 선택할 수 있도록 수정.
  - `Button` 컴포넌트의 variant 속성 추가하여 버튼 디자인을 개선.
  
- **검색 페이지 관련 수정**  
  - 사용자의 위치를 기준으로 2km 반경 내에서 장소를 검색하는 기능 추가.
  - 검색 결과 리스트 UI 개선 및 장소 추가/삭제 기능 구현.

- **지도 관련 수정**  
  - 지도에서 선택한 장소를 검색 페이지에 추가하는 기능 구현.
  - `Place` 타입 정의 및 관련 타입을 `input` 타입과 연결.
  - 최근 검색 기록을 반영하여 검색 결과가 갱신될 때 기존 검색 기록을 표시.

- **기타 수정 사항**  
  - 지도 객체들을 `ref`로 변경하여 리렌더링을 최소화하고 성능 최적화.
  - 하루 선택 페이지에서 미선택 시 버튼 비활성화 및 UI 상태 변경.
  - 장소 검색 관련 페이지 이동 수정 및 지도에서 현재 위치 주소 뱃지 생성.
  - 로그 등록 페이지와 연결하여 네비게이션 흐름 추가.

## 📚 추가 내용 (선택)

