### PR TITLE
배포 시 타입 에러 수정

### DIFF
--- a/src/pages/register/DetailsPage.tsx
+++ b/src/pages/register/DetailsPage.tsx
@@ -39,7 +39,7 @@ const DetailsPage = () => {
 
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
-  const handleSubmit = (e) => {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     console.log('제출');
   };


### PR DESCRIPTION
## 📌 작업 주제

- 이벤트 핸들러에 타입 추가

## 🛠 작업 내용

- 이벤트 핸들러가 form 제출 이벤트를 다루므로 `React.FormEvent<HTMLFormElement>` 타입 추가
