### PR TITLE
fix: RefreshToken 만료 시 불필요한 재요청 방지

### DIFF
--- a/src/services/apis/authApi.ts
+++ b/src/services/apis/authApi.ts
@@ -4,6 +4,8 @@ export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 class AuthClient {
   private instance: AxiosInstance;
+  private lastRefreshAttempt: number = 0; // 마지막 Refresh 요청 시각 저장
+  private refreshFailed: boolean = false; // RefreshToken 만료 후 재요청 방지
 
   constructor(baseURL: string) {
     this.instance = axios.create({
@@ -29,9 +31,23 @@ class AuthClient {
       (response: AxiosResponse) => response,
       async (error) => {
         const originalRequest = error.config;
+        const now = Date.now();
 
+        // 1분 내에 RefreshToken 재요청 금지
+        if (this.refreshFailed) {
+          console.warn('🚨 RefreshToken이 만료됨 → 추가 요청 차단');
+          return Promise.reject(error);
+        }
+
+        // 403 응답 시 1분 내 재요청 방지
         if (error.response?.status === 403 && !originalRequest._retry) {
-          originalRequest._retry = true; // 무한 루프 방지
+          if (now - this.lastRefreshAttempt < 60000) {
+            console.warn('⏳ 1분 이내에 RefreshToken 요청이 실행됨. 중복 요청 방지.');
+            return Promise.reject(error);
+          }
+
+          originalRequest._retry = true;
+          this.lastRefreshAttempt = now; // 마지막 시도 시간 기록
 
           try {
             console.log('AccessToken 만료 → RefreshToken으로 재발급 요청');
@@ -42,7 +58,7 @@ class AuthClient {
             return this.instance(originalRequest); // 기존 요청 재시도
           } catch (err) {
             console.error('RefreshToken도 만료 → 로그아웃 필요');
-            window.location.href = '/';
+            this.refreshFailed = true; // RefreshToken 만료 상태 설정 (1분 동안 재시도 안 함)
             return Promise.reject(err);
           }
         }


### PR DESCRIPTION
## 🐞 버그 설명

 - 리프레시 토큰 만료 시 불필요한 재요청 발생

## 📌 재현 방법

#### 1. 어떤 환경에서 발생했는지? (브라우저, OS 등)
 - 브라우저

#### 2. 버그를 재현하는 단계
 - 로그인 후 일정 시간이 지나 액세스 토큰이 만료됨
 - 리프레시 토큰도 만료된 상태에서 API 요청을 보냄
 - `/auth/refresh` 요청이 반복적으로 발생하면서 무한 요청 상태가 됨

## ✅ 기대한 동작

 - 리프레시 토큰이 만료되었을 경우, 1분 내에 `/auth/refresh` 요청을 다시 보내지 않도록 제한해야 함.
 - 리프레시 토큰이 없거나 만료된 경우, 추가 요청 없어야 함

## 📚 추가 정보

 - refreshFailed 상태 변수를 추가하여 리프레시 토큰만료 시 1분 동안 추가 요청을 막는 방식으로 해결
 - 현재 코드에서는 리프레시 토큰이 만료되면 `/auth/refresh` 요청을 다시 시도하지 않고, 추가 API 요청이 자동으로 차단됨
 - 1분 동안 API 재요청을 하지 않도록 lastRefreshAttempt가 적용됨
 -  유저가 다시 로그인하기 전까지는 더 이상 자동으로 액세스 토큰을 갱신하지 않음
 - 추후 다른 방식으로 개선할 예정