### PR TITLE
유저정보 이미지 관련 로직 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.54.2",
     "react-icons": "^5.4.0",
+    "react-image-file-resizer": "^0.4.8",
     "react-query-devtools": "^2.6.3",
     "react-router-dom": "^7.1.3",
     "sockjs-client": "^1.6.1",

--- a/src/components/Header/MainHeader/components/SearchBarButton.tsx
+++ b/src/components/Header/MainHeader/components/SearchBarButton.tsx
@@ -1,11 +1,11 @@
+import { SearchIcon } from '@/components/Icons';
 import { useSearchStore } from '@/store/searchStore';
-import search from '@/assets/homepage/search.png';
 
 export default function SearchBarButton() {
   const { toggleSearchBar } = useSearchStore();
   return (
     <button onClick={toggleSearchBar}>
-      <img src={search} alt="search_logo" className="object-contain w-[20px] h-[20px]" />
+      <SearchIcon className="w-[20px] h-[20px]" />
     </button>
   );
 }

--- a/src/components/Header/MainHeader/components/UserProfileButton/UserProfileButton.tsx
+++ b/src/components/Header/MainHeader/components/UserProfileButton/UserProfileButton.tsx
@@ -53,12 +53,10 @@ function UserProfileButton() {
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <div className="m-1">
-          <Link to="">
-            <DropdownMenuItem className="flex items-center justify-start gap-2 px-4 py-3 text-text-sm">
-              <SettingIcon />
-              설정
-            </DropdownMenuItem>
-          </Link>
+          <DropdownMenuItem className="flex items-center justify-start gap-2 px-4 py-3 text-text-sm">
+            <SettingIcon />
+            설정
+          </DropdownMenuItem>
           <DropdownMenuItem className="flex items-center justify-start gap-2 px-4 py-3 text-text-sm">
             <HeadPhoneIcon />
             문의하기

--- a/src/components/Icons/SearchIcon.tsx
+++ b/src/components/Icons/SearchIcon.tsx
@@ -1,4 +1,6 @@
-function SearchIcon() {
+import { SVGProps } from 'react';
+
+function SearchIcon(props: SVGProps<SVGSVGElement>) {
   return (
     <svg
       className="m-0"
@@ -7,6 +9,7 @@ function SearchIcon() {
       height="18"
       viewBox="0 0 19 18"
       fill="none"
+      {...props}
     >
       <path
         d="M14.375 13.875L17 16.5M16.25 8.625C16.25 4.68997 13.06 1.5 9.125 1.5C5.18997 1.5 2 4.68997 2 8.625C2 12.56 5.18997 15.75 9.125 15.75C13.06 15.75 16.25 12.56 16.25 8.625Z"

--- a/src/components/Icons/index.ts
+++ b/src/components/Icons/index.ts
@@ -5,3 +5,4 @@ export { default as SpotIcon } from './SpotIcon';
 export { default as StarIcon } from './StarIcon';
 export { default as SubtractIcon } from './SubtractIcon';
 export { default as TableIcon } from './TableIcon';
+export { default as SearchIcon } from './SearchIcon';

--- a/src/features/profile-setting/ProfileSettingAvatar.tsx
+++ b/src/features/profile-setting/ProfileSettingAvatar.tsx
@@ -1,7 +1,7 @@
 import PenIcon from '@/components/Icons/PenIcon';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import useImagePreview from '@/hooks/useImagePreview';
-import { useRef } from 'react';
+import { useProfileStore } from '@/store/profileStore';
+import { useEffect, useRef, useState } from 'react';
 
 interface ProfileSettingAvatarProps {
   imageUrl: string;
@@ -10,7 +10,39 @@ interface ProfileSettingAvatarProps {
 export default function ProfileSettingAvatar({ imageUrl }: ProfileSettingAvatarProps) {
   const hiddenInputRef = useRef<HTMLInputElement>(null);
   const handleImageClick = () => hiddenInputRef.current?.click();
-  const { imagePreview, handleFileChange } = useImagePreview(imageUrl);
+  const { setFile } = useProfileStore();
+
+  const initialImageUrl = imageUrl;
+
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [imagePreview, setImagePreview] = useState<string>(initialImageUrl);
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    console.log('file', file?.name);
+
+    if (file) {
+      setImageFile(file);
+      setFile(file);
+    } else {
+      //이미지가 이미 있을 때 이미지를 새로 선택 안 할 경우 취소
+      setImageFile(null); // 메모리 해제
+      setImagePreview(initialImageUrl);
+    }
+  };
+
+  //이미지 미리보기
+  useEffect(() => {
+    if (imageFile) {
+      const url = URL.createObjectURL(imageFile);
+      setImagePreview(url);
+
+      // 미리보기가 있을 때만 클린업 함수로 메모리 해제
+      return () => {
+        URL.revokeObjectURL(url);
+      };
+    }
+  }, [imageFile, initialImageUrl]);
 
   return (
     <div className="flex justify-center ">

--- a/src/features/profile/OtherUserProfileSection.tsx
+++ b/src/features/profile/OtherUserProfileSection.tsx
@@ -19,7 +19,7 @@ export default function OtherUserProfileSection({ userId }: OtherUserProfileSect
     <div className="flex items-center gap-2 py-[15px]">
       <Link to={`/profile/${userId}`} className="flex items-center gap-2">
         <Avatar className="w-6 h-6">
-          <AvatarImage src={data?.imageUrl} alt="user Avatar" />
+          <AvatarImage src={data?.profileImage.imageUrl} alt="user Avatar" />
         </Avatar>
         <div className="flex items-center gap-1.5">
           <p className="font-semibold text-text-sm">{data?.name}</p>

--- a/src/features/profile/ProfileHeader.tsx
+++ b/src/features/profile/ProfileHeader.tsx
@@ -29,7 +29,7 @@ function ProfileHeader() {
         <section className="flex flex-col items-center justify-start w-full pb-5 web:pb-[30px]">
           <section>
             <Avatar className="w-[60px] h-[60px]">
-              <AvatarImage src={data?.imageUrl} alt={`${data?.name}님의 프로필`} />
+              <AvatarImage src={data?.profileImage.imageUrl} alt={`${data?.name}님의 프로필`} />
             </Avatar>
           </section>
           <section className="gap-[6px] flex justify-center items-center my-3">

--- a/src/pages/profile-setting/index.tsx
+++ b/src/pages/profile-setting/index.tsx
@@ -8,22 +8,53 @@ import useUnsavedChangesWarning from '@/hooks/form/useUnsavedChangesWarning';
 import useUpdateUser from '@/hooks/mutations/user/useUpdateUser';
 import useUser from '@/hooks/queries/user/useUser';
 import PageLayout from '@/layouts/PageLayout';
+import api from '@/services/apis/api';
 import { profileSettingSchema } from '@/services/schemas/profileSchema';
+import { useProfileStore } from '@/store/profileStore';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useCallback } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { z } from 'zod';
+import Resizer from 'react-image-file-resizer';
+
+export const resizeFile = (file: File): Promise<File> => {
+  return new Promise((resolve) => {
+    Resizer.imageFileResizer(
+      file,
+      150, // max width
+      150, // max height
+      'WEBP', // format (JPEG, PNG, WEBP)
+      80, // quality (0~100)
+      0, // rotation
+      (uri) => {
+        resolve(uri as File);
+      },
+      'file' // output type (base64, blob, file)
+    );
+  });
+};
+
+const fetchPresignedUrl = async (file: File) => {
+  try {
+    const result = await api.register.getPresignUrl({ originalFile: file.name });
+
+    return result;
+  } catch (error) {
+    console.error('presigned URL 가져오기 실패', error);
+  }
+};
 
 function ProfileSetting() {
   const nav = useNavigate();
   const { user } = useUser('userOnly');
+  const { file } = useProfileStore();
 
   const form = useForm({
     resolver: zodResolver(profileSettingSchema),
     defaultValues: {
       name: user?.name ?? '',
-      imageUrl: user?.imageUrl ?? 'https://github.com/shadcn.png',
+      imageUrl: user?.profileImage.imageUrl ?? '',
       description: user?.description ?? '',
       instagramId: user?.instagramId ?? '',
     },
@@ -32,8 +63,25 @@ function ProfileSetting() {
   const { mutate } = useUpdateUser();
   const { isFormDirty, setIsFormDirty } = useUnsavedChangesWarning(form);
 
-  const onSubmit = (data: z.infer<typeof profileSettingSchema>) => {
-    mutate(data);
+  const onSubmit = async (data: z.infer<typeof profileSettingSchema>) => {
+    console.log('폼 데이터', data);
+    const { name, description, instagramId } = data;
+
+    console.log('useProfileStore', file);
+    if (!file) return;
+    const resizingFile = await resizeFile(file);
+
+    const presignedUrl = await fetchPresignedUrl(resizingFile);
+    if (!presignedUrl) return;
+    await api.register.uploadImageWithPresignUrl(presignedUrl.preSignedUrl, resizingFile);
+
+    mutate({
+      name,
+      description,
+      instagramId,
+      originalFile: resizingFile.name,
+      uuid: presignedUrl.uuid,
+    });
     setIsFormDirty(false);
   };
 
@@ -54,7 +102,7 @@ function ProfileSetting() {
       <div className="w-screen web:w-[661px] flex flex-col px-4 web:px-0">
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col w-full">
-            <ProfileSettingAvatar imageUrl={String(user?.imageUrl)} />
+            <ProfileSettingAvatar imageUrl={String(user?.profileImage.imageUrl)} />
             <p className="mt-8 mb-4 font-bold text-text-lg web:text-text-2xl">프로필 편집</p>
             <ProfileSettingForm />
             <AccountSettings />

--- a/src/services/apis/types/userAPI.d.ts
+++ b/src/services/apis/types/userAPI.d.ts
@@ -36,7 +36,8 @@ export interface IOhterUser extends IUser {
 
 export interface IUpdateUser {
   name: string;
-  imageUrl: string;
+  originalFile: string;
+  uuid: string;
   description: string;
   instagramId: string;
 }

--- a/src/services/apis/types/userAPI.d.ts
+++ b/src/services/apis/types/userAPI.d.ts
@@ -24,7 +24,7 @@ export interface IUser {
   userId: number;
   name: string;
   instagramId: string;
-  imageUrl: string;
+  profileImage: { imageId: number | null; imageUrl: string };
   description: string;
   follower: number;
   following: number;

--- a/src/services/apis/userApi.ts
+++ b/src/services/apis/userApi.ts
@@ -1,4 +1,5 @@
 import { IOhterUser, IUpdateUser, IUser } from '@/services/apis/types/userAPI';
+import { getImgFromCloudFront } from '@/utils/getImgFromCloudFront';
 import { AxiosInstance } from 'axios';
 
 export class UserAPI {
@@ -10,7 +11,18 @@ export class UserAPI {
   /* 로그인된 사용자 정보 가져오기 */
   async getUser(): Promise<IUser> {
     const response = await this.axios.get('/api/users');
-    return response.data;
+    const data = response.data;
+
+    return {
+      ...data,
+      profileImage: {
+        ...data.profileImage,
+        imageUrl:
+          data.profileImage.imageId === null
+            ? data.profileImage.imageUrl
+            : getImgFromCloudFront(data.profileImage.imageUrl),
+      },
+    };
   }
 
   async deleteUser() {
@@ -32,6 +44,17 @@ export class OtherUserAPI {
 
   async getOtherUser(userId: number): Promise<IOhterUser> {
     const response = await this.axios.get(`/api/users/${userId}`);
-    return response.data;
+    const data = response.data;
+
+    return {
+      ...data,
+      profileImage: {
+        ...data.profileImage,
+        imageUrl:
+          data.profileImage.imageId === null
+            ? data.profileImage.imageUrl
+            : getImgFromCloudFront(data.profileImage.imageUrl),
+      },
+    };
   }
 }

--- a/src/store/profileStore.ts
+++ b/src/store/profileStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface ProfileState {
+  file: File | null;
+  setFile: (file: File) => void;
+}
+
+export const useProfileStore = create<ProfileState>((set) => ({
+  file: null,
+  setFile: (file) => set({ file }),
+}));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2364,6 +2364,11 @@ react-icons@^5.4.0:
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-5.4.0.tgz#443000f6e5123ee1b21ea8c0a716f6e7797f7416"
   integrity sha512-7eltJxgVt7X64oHh6wSWNwwbKTCtMfK35hcjvJS0yxEAhPM8oUKdS3+kqaW1vicIltw+kR2unHaa12S9pPALoQ==
 
+react-image-file-resizer@^0.4.8:
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/react-image-file-resizer/-/react-image-file-resizer-0.4.8.tgz#85f4ae4469fd2867d961568af660ef403d7a79af"
+  integrity sha512-Ue7CfKnSlsfJ//SKzxNMz8avDgDSpWQDOnTKOp/GNRFJv4dO9L5YGHNEnj40peWkXXAK2OK0eRIoXhOYpUzUTQ==
+
 react-query-devtools@^2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/react-query-devtools/-/react-query-devtools-2.6.3.tgz#f7c982839d4b0001cee4d5ddfa826493c2f6341f"


### PR DESCRIPTION
## 📌 작업 주제

- 유저 이미지 업로드 방식 변경에 따라 관련 코드 수정

## 🛠 작업 내용

- 가입 이후 유저 이미지 변경 전, 후 패칭되는 url에 따라 getImgFromCloudFront 함수 적용
- react-image-file-resizer로 이미지 업로드 시 최적화
- 돋보기 아이콘 svg로 변경

## 📚 추가 내용 (선택)

### 가입 이후 이미지 변경 없을 때
```json
  "profileImage": {
  "imageUrl": "http://k.kakaocdn.net/dn/bAN6Ha/btsMExRLjY2/IqpgErIEJm6lsaRdSUiHVk/img_640x640.jpg",
  "imageId": null
}
```

### 이미지 변경 이후 S3 업로드한 이미지 응답올 때
```json
  "profileImage": {
  "imageUrl": "5fbdeede-69e9-409a-8089-8224e955173c_이미지1",
  "imageId": 13
}
```
