### PR TITLE
유저정보 수정 페이지 이탈 시 alert창 2번 뜨는 현상 해결

### DIFF
--- a/src/pages/profile-setting/index.tsx
+++ b/src/pages/profile-setting/index.tsx
@@ -61,7 +61,7 @@ function ProfileSetting() {
   });
 
   const { mutate } = useUpdateUser();
-  const { isFormDirty, setIsFormDirty } = useUnsavedChangesWarning(form);
+  const { setIsFormDirty } = useUnsavedChangesWarning(form);
 
   const onSubmit = async (data: z.infer<typeof profileSettingSchema>) => {
     console.log('폼 데이터', data);
@@ -91,10 +91,6 @@ function ProfileSetting() {
   }, [form, onSubmit]);
 
   const handleNavigation = () => {
-    if (isFormDirty) {
-      const confirmLeave = window.confirm('저장하지 않고 나가시겠습니까?');
-      if (!confirmLeave) return;
-    }
     nav(-1); // 이전 페이지로 이동
   };
   return (


### PR DESCRIPTION
## 📌 작업 주제

- 유저정보 수정 페이지 이탈 시 alert창 2번 뜨는 현상 해결

## 🛠 작업 내용

- 뒤로가기 버튼의 alert창 관련 로직이 원인
- 해당 로직을 삭제하여 해결

## 📚 추가 내용 (선택)

- 추가로 공유하고 싶은 내용이 있다면 작성해주세요.
