### PR TITLE
검색 페이지 UI 수정, 마이페이지 fallback 추가 및 위치 권한 모달 개선

### DIFF
--- a/src/components/CustomPagination.tsx
+++ b/src/components/CustomPagination.tsx
@@ -15,9 +15,9 @@ interface CustomPaginationProps {
 }
 
 export default function CustomPagination({ currentPage, totalPages }: CustomPaginationProps) {
-  const [_, setSearchParams] = useSearchParams();
+  if (totalPages <= 1 || !currentPage) return null;
 
-  if (totalPages === 1) return null;
+  const [_, setSearchParams] = useSearchParams();
 
   const handlePageChange = (page: number) => {
     setSearchParams({ pageNumber: page.toString() });

--- a/src/components/GeoConsentModal.tsx
+++ b/src/components/GeoConsentModal.tsx
@@ -17,7 +17,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 export default function GeoConsentModal() {
   const nav = useNavigate();
   const { pathname } = useLocation();
-  const { open, setOpen } = useGeolocationStore();
+  const { open, setOpen, permission } = useGeolocationStore();
 
   /* 위치 요청 함수 (모달에서 동의 시 실행) */
   const requestLocation = () => {
@@ -36,7 +36,13 @@ export default function GeoConsentModal() {
   /* 모달 닫을 때, 현재 경로가 /register로 시작하면 홈으로 이동 */
   const handleClose = (isOpen: boolean) => {
     setOpen(isOpen);
-    if (!isOpen && pathname.startsWith('/register')) {
+    if (pathname.startsWith('/register') && permission !== 'granted' && !isOpen) {
+      nav(-1);
+    }
+  };
+  const onCencelClick = () => {
+    setOpen(false);
+    if (pathname.startsWith('/register') && permission !== 'granted') {
       nav(-1);
     }
   };
@@ -70,11 +76,7 @@ export default function GeoConsentModal() {
             </DialogDescription>
           </DialogHeader>
           <DialogFooter className="flex flex-row items-center gap-2 py-5">
-            <Button
-              onClick={() => setOpen(false)}
-              variant="outline"
-              className="flex-1 font-semibold"
-            >
+            <Button onClick={onCencelClick} variant="outline" className="flex-1 font-semibold">
               거절
             </Button>
             <Button className="font-semibold web:flex-1" onClick={requestLocation}>

--- a/src/components/Header/SectionHeader.tsx
+++ b/src/components/Header/SectionHeader.tsx
@@ -20,7 +20,7 @@ function SectionHeader({
     <header className={cn('flex flex-col', className)}>
       <h2
         className={cn(
-          'text-[24px] web:text-[32px] leading-[120%] tracking-[-0.48px] web:tracking-[-0.64px] text-primary-400 font-medium',
+          'text-[24px] web:text-[32px] leading-[120%] tracking-[-0.48px] web:tracking-[-0.64px] text-primary-400 font-untitled font-medium',
           labelClassName
         )}
       >
@@ -28,7 +28,7 @@ function SectionHeader({
       </h2>
       <h2
         className={cn(
-          'text-[24px] web:text-[32px] leading-[120%] tracking-[-0.48px] web:tracking-[-0.64px] text-primary-950 font-medium',
+          'text-[24px] web:text-[32px] leading-[120%] tracking-[-0.48px] web:tracking-[-0.64px] text-primary-950 font-untitled font-medium',
           queryClassName
         )}
       >

--- a/src/features/profile/PostCard/index.ts
+++ b/src/features/profile/PostCard/index.ts
@@ -2,3 +2,5 @@ export { default as PostCardWrapper } from './PostCardWrapper';
 export { default as PostCardImage } from './PostCardImage';
 export { default as PostCardTitle } from './PostCardTitle';
 export { default as PostCardLocation } from './PostCardLocation';
+export { default as ProfileFallbackMessage } from '../fallback/ProfileFallbackMessage';
+export { default as ProfileMyLogFallback } from '../fallback/ProfileMyLogFallback';

--- a/src/features/profile/ProfileHeader.tsx
+++ b/src/features/profile/ProfileHeader.tsx
@@ -68,7 +68,7 @@ function ProfileHeader() {
             <Link to="/profile-setting">
               <Button
                 variant="outline"
-                className="mt-[10px] web:mt-[15px] p-2 w-[50px] web:w-[60px] h-[24px] web:h-[28px] rounded-[60px] font-medium text-text-xs"
+                className="mt-[10px] min-h-0 web:mt-[15px] p-2 w-[50px] web:w-[60px] h-[24px] web:h-[28px] rounded-[60px] font-medium text-text-xs"
               >
                 편집
               </Button>

--- a/src/features/profile/TapNavigation.tsx
+++ b/src/features/profile/TapNavigation.tsx
@@ -16,7 +16,8 @@ function TapNavigation() {
         <Separator orientation="vertical" className="web:h-[20px] mobile:h-[18px]" />
       </div>
       <Button
-        className="rounded-[60px] web:text-text-sm mobile:text-text-xs"
+        size="s"
+        className="rounded-[60px] px-4 py-[11px] h-7 web:h-9 web:text-text-sm font-untitled"
         onClick={handleGotoRegisterPage}
       >
         Upload

--- a/src/features/profile/fallback/ProfileFallbackMessage.tsx
+++ b/src/features/profile/fallback/ProfileFallbackMessage.tsx
@@ -1,8 +1,12 @@
-export default function NotProfileData() {
+interface ProfileFallbackMessageProps {
+  resourceName: string;
+}
+
+export default function ProfileFallbackMessage({ resourceName }: ProfileFallbackMessageProps) {
   return (
     <div className="flex justify-center items-center py-[49px]">
       <h3 className="font-bold text-center text-text-sm text-primary-200">
-        저장된 장소가 없습니다.
+        저장된 {resourceName}가 없습니다.
         <br /> 로그를 둘러본뒤 관심있는 장소를 저장해보세요!
       </h3>
     </div>

--- a/src/features/profile/fallback/ProfileMyLogFallback.tsx
+++ b/src/features/profile/fallback/ProfileMyLogFallback.tsx
@@ -1,0 +1,19 @@
+import { REGISTER_SELECT } from '@/constants/pathname';
+import { PlusIcon } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+export default function ProfileMyLogFallback() {
+  return (
+    <section className="flex w-full">
+      <Link
+        to={REGISTER_SELECT}
+        className="w-full web:w-[324px] aspect-[343/218] web:aspect-[324/218] rounded-xl flex flex-col justify-center items-center gap-2.5 border border-dashed border-primary-200"
+      >
+        <PlusIcon className="w-6 h-6 stroke-[1.2] stroke-primary-200" />
+        <p className="font-bold text-center text-text-sm text-primary-200">
+          나만의 로그 <br /> 첫 게시물을 올려보세요!
+        </p>
+      </Link>
+    </section>
+  );
+}

--- a/src/features/search/SearchTitleHeader.tsx
+++ b/src/features/search/SearchTitleHeader.tsx
@@ -6,7 +6,7 @@ interface SearchTitleHeaderProps {
 export default function SearchTitleHeader({ labelText, queryText }: SearchTitleHeaderProps) {
   return (
     <header className="gap-[5px] web:gap-2 items-start pb-10 web:pb-[60px] border-b-[1px] border-b-primary-100 w-full flex flex-col">
-      <h2 className="text-[24px] web:text-[32px] leading-[120%] tracking-[-0.48px] web:tracking-[-0.64px] text-primary-400 font-bold">
+      <h2 className="font-untitled text-[24px] web:text-[32px] leading-[120%] tracking-[-0.48px] web:tracking-[-0.64px] text-primary-400 font-bold">
         {labelText}
       </h2>
       <h2 className="text-[24px] leading-[135%] web:leading-[130%] tracking-[-0.24px] web:tracking-[-0.64px] text-primary-950 font-bold">

--- a/src/layouts/RegisterLayout.tsx
+++ b/src/layouts/RegisterLayout.tsx
@@ -1,13 +1,22 @@
 import GeoConsentModal from '@/components/GeoConsentModal';
 import { KakaoMapProvider } from '@/contexts/KakaoMap.context';
 import useGeolocationPermission from '@/hooks/useGeolocationPermission';
-import { Outlet, useLocation } from 'react-router-dom';
+import { useEffect } from 'react';
+import { Outlet } from 'react-router-dom';
 
 const RegisterLayout = () => {
   /* /register로 시작하는 url 진입 시 위치권한 동의 여부에 따라 모달창 렌더링*/
-  const { pathname } = useLocation();
-  const isRegister = pathname.startsWith('/register');
-  const { open } = useGeolocationPermission();
+  const { setOpen, permission, checkPermission } = useGeolocationPermission();
+
+  useEffect(() => {
+    checkPermission();
+  }, []);
+
+  useEffect(() => {
+    if (permission !== 'granted') {
+      setOpen(true);
+    }
+  }, [permission]);
   return (
     <div className="flex flex-col items-center h-screen mx-auto web:w-[724px]">
       <div className="w-full h-full grow">
@@ -15,7 +24,7 @@ const RegisterLayout = () => {
           <Outlet />
         </KakaoMapProvider>
       </div>
-      {isRegister && open && <GeoConsentModal />}
+      {permission !== 'granted' && <GeoConsentModal />}
     </div>
   );
 };

--- a/src/pages/profile/my-logs/index.tsx
+++ b/src/pages/profile/my-logs/index.tsx
@@ -6,13 +6,13 @@ import {
   PostCardLocation,
   PostCardTitle,
   PostCardWrapper,
+  ProfileMyLogFallback,
 } from '@/features/profile/PostCard';
 import useUser from '@/hooks/queries/user/useUser';
 import useOtherUserLogs from '@/hooks/queries/userLog/useOtherUserLogs';
 import useUserLogs from '@/hooks/queries/userLog/useUserLogs';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
 import { getImgFromCloudFront } from '@/utils/getImgFromCloudFront';
-import NotProfileData from '../NotProfileData';
 import SaveLogBookMarkButton from '@/features/profile/profileBookMark/SaveLogBookMarkButton';
 
 function MyLogs() {
@@ -41,7 +41,7 @@ function MyLogs() {
     <>
       {isPending ? (
         <Loading className="min-h-[350px]" />
-      ) : data?.content.length !== 0 ? (
+      ) : data?.content.length === 0 ? (
         <>
           <PostCardWrapper className="mb-[50px]">
             {data?.content?.map((log) => (
@@ -70,7 +70,7 @@ function MyLogs() {
           </section>
         </>
       ) : (
-        <NotProfileData />
+        <ProfileMyLogFallback />
       )}
     </>
   );

--- a/src/pages/profile/saved-logs/index.tsx
+++ b/src/pages/profile/saved-logs/index.tsx
@@ -13,9 +13,9 @@ import useUserBookmarkLogs from '@/hooks/queries/userLog/useUserBookmarkLogs';
 import { getImgFromCloudFront } from '@/utils/getImgFromCloudFront';
 import { Link, useSearchParams } from 'react-router-dom';
 import { useParams } from 'react-router-dom';
-import NotProfileData from '../NotProfileData';
 import SaveLogBookMarkButton from '@/features/profile/profileBookMark/SaveLogBookMarkButton';
 import { useLayoutEffect } from 'react';
+import ProfileFallbackMessage from '@/features/profile/fallback/ProfileFallbackMessage';
 
 function SavedLogs() {
   const { user } = useUser();
@@ -85,7 +85,7 @@ function SavedLogs() {
           </section>
         </>
       ) : (
-        <NotProfileData />
+        <ProfileFallbackMessage resourceName="로그" />
       )}
     </>
   );

--- a/src/pages/profile/saved-spaces/index.tsx
+++ b/src/pages/profile/saved-spaces/index.tsx
@@ -12,9 +12,9 @@ import useOtherUserBookmarkPlaces from '@/hooks/queries/userLog/useOtherUserBook
 import useUserBookmarkPlaces from '@/hooks/queries/userLog/useUserBookmarkPlaces';
 import { getImgFromCloudFront } from '@/utils/getImgFromCloudFront';
 import { useParams, useSearchParams } from 'react-router-dom';
-import NotProfileData from '../NotProfileData';
 import SavePlaceBookMarkButton from '@/features/profile/profileBookMark/SavePlaceBookMarkButton';
 import { useLayoutEffect } from 'react';
+import ProfileFallbackMessage from '@/features/profile/fallback/ProfileFallbackMessage';
 
 function SavedSpaces() {
   const { user } = useUser();
@@ -82,7 +82,7 @@ function SavedSpaces() {
           </section>
         </>
       ) : (
-        <NotProfileData />
+        <ProfileFallbackMessage resourceName="장소" />
       )}
     </>
   );

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -50,7 +50,7 @@ function Search() {
           <SearchNotFound />
         ) : (
           <>
-            <div className="flex flex-col gap-y-[34px] web:grid web:grid-cols-4 web:grid-rows-4 web:gap-x-[15px] web:gap-y-10 mt-6 web:mt-[50px]">
+            <div className="flex flex-col gap-y-[34px] web:grid web:grid-cols-4 web:gap-x-[15px] web:gap-y-10 mt-6 web:mt-[50px]">
               {data?.content?.map((log, idx: number) => {
                 const isLarge = idx === 2;
 


### PR DESCRIPTION
## 📌 작업 주제

- 검색 페이지 폴리싱
- 페이지네이션 예외처리 추가
- 마이페이지 fallback 컴포넌트 추가
- RegisterLayout에서 위치 권한 모달 버그 수정

## 🛠 작업 내용

- 검색페이지 타이틀 폰트 수정
- 페이지네이션이 api 패칭 에러 상황에서도 안 보이게 예외처리 추가
- 마이메페이지(나의 로그) fallback 컴포넌트 추가
- RegisterLayout 진입 시 위치 권한 모달이 렌더링 되지 않던 현상 수정

## 📚 추가 내용 (선택)
### 마이페이지(마이 로그) fallback 컴포넌트 border 스타일
<img width="301" alt="Image" src="https://github.com/user-attachments/assets/25203d82-da27-4572-b31f-a6e6c2136809" />

- `border-dashed`의 점선 간격(대시 길이와 간격)은 기본적으로 브라우저에 의해 정해지기 때문에 조절이 어렵다.

### 방법
1. git 이미지 사용(간편해서 추천)
2. 이미지를 잘라서 테두리로 사용하는 CSS 기능인 [**border-image**](https://drafts.csswg.org/css-backgrounds-3/#border-images) 사용
