### PR TITLE
회원정보 수정 얼럿창 버그 및 알림 상대시간 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "axios": "^1.7.9",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "dayjs": "^1.11.13",
     "embla-carousel-autoplay": "^8.5.2",
     "embla-carousel-react": "^8.5.2",
     "lodash": "^4.17.21",

--- a/src/components/Header/SectionHeader.tsx
+++ b/src/components/Header/SectionHeader.tsx
@@ -20,7 +20,7 @@ function SectionHeader({
     <header className={cn('flex flex-col', className)}>
       <h2
         className={cn(
-          'text-[24px] web:text-[32px] leading-[120%] tracking-[-0.48px] web:tracking-[-0.64px] text-primary-400 font-untitled font-medium',
+          'text-[24px] web:text-[32px] leading-[120%] tracking-[-0.48px] web:tracking-[-0.64px] text-primary-400 font-untitled font-semibold',
           labelClassName
         )}
       >
@@ -28,7 +28,7 @@ function SectionHeader({
       </h2>
       <h2
         className={cn(
-          'text-[24px] web:text-[32px] leading-[120%] tracking-[-0.48px] web:tracking-[-0.64px] text-primary-950 font-untitled font-medium',
+          'text-[24px] web:text-[32px] leading-[120%] tracking-[-0.48px] web:tracking-[-0.64px] text-primary-950 font-untitled font-semibold',
           queryClassName
         )}
       >

--- a/src/features/follow/ProfileFollowingButton.tsx
+++ b/src/features/follow/ProfileFollowingButton.tsx
@@ -2,12 +2,17 @@ import { Button } from '@/components/ui/button';
 import { useFollowingMutation } from '@/hooks/mutations/follow/useFollowingMutation';
 import { useUnfollowMutation } from '@/hooks/mutations/follow/useUnfollowMutation';
 import useOtherUser from '@/hooks/queries/user/useOtherUser';
+import { cn } from '@/lib/utils';
 
 interface ProfileFollowingButtonProps {
   otherUserId: number;
+  className?: string;
 }
 
-export default function ProfileFollowingButton({ otherUserId }: ProfileFollowingButtonProps) {
+export default function ProfileFollowingButton({
+  otherUserId,
+  className = '',
+}: ProfileFollowingButtonProps) {
   const { data: userData } = useOtherUser(otherUserId);
   const { mutate: onMutate, status: onStatus } = useFollowingMutation();
   const { mutate: unMutate, status: unStatus } = useUnfollowMutation();
@@ -24,7 +29,7 @@ export default function ProfileFollowingButton({ otherUserId }: ProfileFollowing
       onClick={onFollowClick}
       variant={userData && userData?.isFollowing ? 'ghost' : 'outline'}
       size="s"
-      className="font-medium"
+      className={cn('font-medium', ...className)}
       fullRounded
     >
       {userData && userData?.isFollowing ? '팔로잉' : '팔로우'}

--- a/src/features/notification/NotificationButton.tsx
+++ b/src/features/notification/NotificationButton.tsx
@@ -19,7 +19,6 @@ function NotificationButton() {
   //useNotificationWebSocket(); //추후 웹소켓 훅 사용해서 실시간 알림 받기
   const { data: notisData = [], isLoading: isNotiLoading } = useNotificationList();
   const { notifications, isNotiCount, readAsRead } = notificationStore();
-  console.log('notifications', notifications);
 
   useEffect(() => {
     if (Array.isArray(notisData)) {

--- a/src/features/notification/NotificationItem.tsx
+++ b/src/features/notification/NotificationItem.tsx
@@ -27,8 +27,7 @@ export default function NotificationItem({
   console.log('userId', userId);
 
   return (
-    <Link
-      to={`/profile/${userId}`}
+    <div
       key={id}
       onClick={onReadClick}
       className={cn(
@@ -49,6 +48,6 @@ export default function NotificationItem({
           </time>
         </span>
       </figcaption>
-    </Link>
+    </div>
   );
 }

--- a/src/features/notification/NotificationItem.tsx
+++ b/src/features/notification/NotificationItem.tsx
@@ -4,7 +4,6 @@ import { cn } from '@/lib/utils';
 import { Notification } from '@/services/apis/types/notificationAPI';
 import { formatNotificationJSX } from '@/utils/notificationUtils';
 import { formatRelativeTime } from '@/utils/timeUtils';
-import { Link } from 'react-router-dom';
 
 interface NotificationItemProps extends Notification {
   readAsReadClick: () => void;
@@ -25,7 +24,6 @@ export default function NotificationItem({
     readAsReadClick();
   };
   console.log('userId', userId);
-
   return (
     <div
       key={id}

--- a/src/features/profile/ProfileHeader.tsx
+++ b/src/features/profile/ProfileHeader.tsx
@@ -8,6 +8,7 @@ import useOtherUser from '@/hooks/queries/user/useOtherUser';
 import ProfileHeaderSkeleton from '@/components/Skeleton/ProfileHeaderSkeleton';
 import FollowingListButton from '../follow/FollowingListButton';
 import FollowerListButton from '../follow/FollowerListButton';
+import ProfileFollowingButton from '../follow/ProfileFollowingButton';
 
 function ProfileHeader() {
   const { userId } = useParams();
@@ -68,7 +69,7 @@ function ProfileHeader() {
             </h3>
             <h3>{data?.instagramId ? data.instagramId : '@spoteditorofficial'}</h3>
           </section>
-          {isMe && (
+          {isMe ? (
             <Link to="/profile-setting">
               <Button
                 variant="outline"
@@ -77,6 +78,11 @@ function ProfileHeader() {
                 편집
               </Button>
             </Link>
+          ) : (
+            <ProfileFollowingButton
+              otherUserId={Number(otherUserData?.userId)}
+              className="mt-[10px] min-h-0 web:mt-[15px] p-2 w-[50px] web:w-[60px] h-[24px] web:h-[28px] rounded-[60px] font-medium text-text-xs"
+            />
           )}
         </section>
       )}

--- a/src/hooks/form/useUnsavedChangesWarning.ts
+++ b/src/hooks/form/useUnsavedChangesWarning.ts
@@ -1,56 +1,61 @@
-import { useEffect, useState } from 'react';
-import { useBlocker } from 'react-router-dom';
-import { UseFormReturn } from 'react-hook-form';
+import { useProfileNavigationStore } from '@/store/profileStore';
+import { useEffect } from 'react';
 
-export default function useUnsavedChangesWarning(form: UseFormReturn<any>) {
-  const [isFormDirty, setIsFormDirty] = useState(false);
-  const [proceedNavigation, setProceedNavigation] = useState(false);
+export function useBlocker(blocker: (tx: any) => void, when = true) {
+  const navigator = useProfileNavigationStore((state) => state.navigator);
 
-  // 1. 폼 변경 감지
   useEffect(() => {
-    const subscription = form.watch(() => {
-      setIsFormDirty(true);
-    });
+    if (!when || !navigator) return;
 
-    return () => subscription.unsubscribe();
-  }, [form]);
+    // unblock을 미리 선언하여 콜백 내부에서 참조 가능하도록 한다.
+    let unblock: () => void;
 
-  // 2. beforeunload 감지 (브라우저 닫기/새로고침)
-  useEffect(() => {
-    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-      if (isFormDirty) {
-        event.preventDefault();
-        event.returnValue = '';
+    const blockHandler = (tx: any) => {
+      const autoUnblockingTx = {
+        ...tx,
+        retry() {
+          // unblock을 호출해서 블록 해제 후 retry 실행
+          if (unblock) {
+            unblock();
+          }
+          tx.retry();
+        },
+      };
+      blocker(autoUnblockingTx);
+    };
+
+    unblock = navigator.block(blockHandler);
+
+    return () => {
+      if (unblock) {
+        unblock();
       }
+    };
+  }, [navigator, blocker, when]);
+}
+
+export function usePrompt(message: string, when = true) {
+  useBlocker((tx: any) => {
+    if (window.confirm(message)) {
+      tx.retry();
+    }
+    // 취소 시 아무 동작 없이 현재 페이지에 머문다.
+  }, when);
+}
+
+export default function useUnsavedChangesWarning(isDirty: boolean) {
+  // 새로고침이나 브라우저 창 닫기 시 경고 처리
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (!isDirty) return;
+      e.preventDefault();
+      e.returnValue = ''; // 대부분 브라우저에서 경고창을 띄움
     };
 
     window.addEventListener('beforeunload', handleBeforeUnload);
-    return () => {
-      window.removeEventListener('beforeunload', handleBeforeUnload);
-    };
-  }, [isFormDirty]);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [isDirty]);
 
-  // 3. 라우터 이동 감지 및 차단
-  const blocker = useBlocker(({ currentLocation, nextLocation }) => {
-    // 진행 여부 결정: 취소 시 false 반환
-    if (isFormDirty && currentLocation.pathname !== nextLocation.pathname && !proceedNavigation) {
-      const confirmLeave = window.confirm('저장하지 않고 나가시겠습니까?');
-      if (confirmLeave) {
-        setProceedNavigation(true); // 다음 useEffect에서 proceed 처리
-        return false; // 진행 허용
-      } else {
-        return true; // 차단
-      }
-    }
-    return false;
-  });
-
-  // blocker.proceed()는 confirm이 true일 때만 실행
-  useEffect(() => {
-    if (blocker.state === 'blocked' && proceedNavigation) {
-      blocker.proceed();
-    }
-  }, [blocker, proceedNavigation]);
-
-  return { isFormDirty, setIsFormDirty };
+  // 라우터 내 페이지 이동 시 경고 처리
+  usePrompt('저장하지 않고 나가시겠습니까?', isDirty);
 }

--- a/src/pages/profile-setting/index.tsx
+++ b/src/pages/profile-setting/index.tsx
@@ -4,7 +4,6 @@ import AccountSettings from '@/features/profile-setting/AccountSettings';
 import ProfileSettingAvatar from '@/features/profile-setting/ProfileSettingAvatar';
 import ProfileSettingForm from '@/features/profile-setting/ProfileSettingForm/ProfileSettingForm';
 import SaveProfileButton from '@/features/profile-setting/SaveProfileButton';
-import useUnsavedChangesWarning from '@/hooks/form/useUnsavedChangesWarning';
 import useUpdateUser from '@/hooks/mutations/user/useUpdateUser';
 import useUser from '@/hooks/queries/user/useUser';
 import PageLayout from '@/layouts/PageLayout';
@@ -17,6 +16,7 @@ import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { z } from 'zod';
 import Resizer from 'react-image-file-resizer';
+import useUnsavedChangesWarning from '@/hooks/form/useUnsavedChangesWarning';
 
 export const resizeFile = (file: File): Promise<File> => {
   return new Promise((resolve) => {
@@ -61,7 +61,9 @@ function ProfileSetting() {
   });
 
   const { mutate } = useUpdateUser();
-  const { setIsFormDirty } = useUnsavedChangesWarning(form);
+
+  /* 폼에 변경사항이 있을 때 페이지 이동이나 새로고침 시 경고창을 띄움 */
+  useUnsavedChangesWarning(form.formState.isDirty);
 
   const onSubmit = async (data: z.infer<typeof profileSettingSchema>) => {
     const { name, description } = data;
@@ -84,7 +86,8 @@ function ProfileSetting() {
       originalFile: resizingFile.name,
       uuid: presignedUrl.uuid,
     });
-    setIsFormDirty(false);
+    /* 저장 후 dirty 상태를 false로 변경하여 경고창이 뜨지 않도록 */
+    form.reset(data);
   };
 
   const handleSaveClick = useCallback(() => {

--- a/src/store/profileStore.ts
+++ b/src/store/profileStore.ts
@@ -9,3 +9,13 @@ export const useProfileStore = create<ProfileState>((set) => ({
   file: null,
   setFile: (file) => set({ file }),
 }));
+
+interface ProfileNavigationStore {
+  navigator: any;
+  setNavigator: (navigator: any) => void;
+}
+
+export const useProfileNavigationStore = create<ProfileNavigationStore>((set) => ({
+  navigator: null,
+  setNavigator: (navigator) => set({ navigator }),
+}));

--- a/src/utils/timeUtils.ts
+++ b/src/utils/timeUtils.ts
@@ -1,26 +1,10 @@
-/* 주어진 날짜로부터 현재 시간까지의 경과 시간을 상대적으로 표현하는 함수 */
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import 'dayjs/locale/ko'; // 한국어 지원
+
+dayjs.extend(relativeTime);
+dayjs.locale('ko');
+
 export const formatRelativeTime = (date: string | Date): string => {
-    const uploadedDate = new Date(date);
-    const now = new Date();
-    const elapsed = now.getTime() - uploadedDate.getTime(); // 경과 시간 (밀리초)
-    const seconds = Math.floor(elapsed / 1000);
-    const minutes = Math.floor(seconds / 60);
-    const hours = Math.floor(minutes / 60);
-    const days = Math.floor(hours / 24);
-    const months = Math.floor(days / 30); // 대략적인 값
-    const years = Math.floor(days / 365); // 대략적인 값
-  
-    if (years > 0) {
-      return `${years}년 전`;
-    } else if (months > 0) {
-      return `${months}달 전`;
-    } else if (days > 0) {
-      return `${days}일 전`;
-    } else if (hours > 0) {
-      return `${hours}시간 전`;
-    } else if (minutes > 0) {
-      return `${minutes}분 전`;
-    } else {
-      return `방금 전`;
-    }
-  };
+  return dayjs(date).fromNow(); // 예: "3일 전", "2분 전", "방금 전"
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1370,6 +1370,11 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
+dayjs@^1.11.13:
+  version "1.11.13"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.13.tgz#92430b0139055c3ebb60150aa13e860a4b5a366c"
+  integrity sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==
+
 debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"


### PR DESCRIPTION
## 📌 작업 주제

- 회원정보 얼럿창 버그 수정
- 검색페이지 타이틀 섹션의 폰트 두께 수정
- 알림 상대시간 수정(dayjs 설치)
- 마이페이지 타유저 팔로우 버튼 추가

## 🛠 작업 내용

- 타유저 프로필페이지에 팔로우 버튼 추가
- 회원정보 수정 후 저장 누를 시 "저장하지 않고 나가시겠습니까?" 얼럿창이 뜨는 버그 수정
- 검색페이지 타이틀의 폰트 두께 600으로 수정
- 알림 상대 시간의 정확도를 위해 dayjs 설치 및 적용

## 📚 추가 내용 (선택)

- 추가로 공유하고 싶은 내용이 있다면 작성해주세요.
