### PR TITLE
프로필 저장 후에도 경고창이 뜨는 문제 해결

### DIFF
--- a/src/features/profile-setting/SaveProfileButton.tsx
+++ b/src/features/profile-setting/SaveProfileButton.tsx
@@ -40,7 +40,7 @@ function SaveProfileButton({ userId, onTrigger }: SaveProfileButtonProps) {
         </DialogDescription>
         <DialogClose asChild className="flex justify-end w-full">
           <div className="space-x-[15px]">
-            <Button onClick={onUpdateClick} size="sm" className="w-[100px]">
+            <Button type="button" onClick={onUpdateClick} size="sm" className="w-[100px]">
               확인
             </Button>
           </div>

--- a/src/pages/profile-setting/index.tsx
+++ b/src/pages/profile-setting/index.tsx
@@ -48,7 +48,7 @@ const fetchPresignedUrl = async (file: File) => {
 function ProfileSetting() {
   const nav = useNavigate();
   const { user } = useUser('userOnly');
-  const { file } = useProfileStore();
+  const { file, clearFile } = useProfileStore();
 
   const form = useForm({
     resolver: zodResolver(profileSettingSchema),
@@ -112,6 +112,7 @@ function ProfileSetting() {
     }
     /* 저장 후 dirty 상태를 false로 변경하여 경고창이 뜨지 않도록 */
     form.reset(data);
+    clearFile();
   };
 
   const handleSaveClick = useCallback(() => {

--- a/src/store/profileStore.ts
+++ b/src/store/profileStore.ts
@@ -3,9 +3,11 @@ import { create } from 'zustand';
 interface ProfileState {
   file: File | null;
   setFile: (file: File) => void;
+  clearFile: () => void;
 }
 
 export const useProfileStore = create<ProfileState>((set) => ({
   file: null,
   setFile: (file) => set({ file }),
+  clearFile: () => set({ file: null }),
 }));


### PR DESCRIPTION
## 📌 작업 주제

- 저장 완료 후에도 useUnsavedChangesWarning 훅에서 isChanged가 true로 평가되어 페이지 이동 시 경고창이 뜨는 문제가 발생

## 🛠 작업 내용

- 이는 상태에 남아있는 파일(file)이 여전히 존재해서 발생한 것으로 판단
- 쥬스탄드 스토어에 clearFile() 메서드를 추가하여 저장 후 file 상태를 초기화
- onSubmit 이후 form.reset(data)와 함께 clearFile() 호출하여 정상적으로 경고 방지

## 📚 추가 내용 (선택)

- 추가로 공유하고 싶은 내용이 있다면 작성해주세요.
